### PR TITLE
SonarCloud projectName and README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # Terra Policy Service
 
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=terra-policy-service&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=terra-policy-service)

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -52,6 +52,7 @@ test {
 
 sonarqube {
     properties {
+        property 'sonar.projectName', 'terra-policy-service' 
         property 'sonar.projectKey', 'terra-policy-service'
         property 'sonar.organization', 'broad-databiosphere'
         property 'sonar.host.url', 'https://sonarcloud.io'


### PR DESCRIPTION
The projectName in build.gradle is needed to label the scan properly in SonarCloud.

The badge in README.md is recommended but not required.