### PR TITLE
[PF-1899] Add retry to database transactions

### DIFF
--- a/buildSrc/src/main/groovy/bio.terra.policy.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.policy.java-common-conventions.gradle
@@ -46,7 +46,7 @@ dependencies {
     testImplementation 'ch.qos.logback:logback-classic:1.2.10'
     testImplementation 'org.hamcrest:hamcrest:2.2'
 
-    implementation 'bio.terra:terra-common-lib:0.0.60-SNAPSHOT'
+    implementation 'bio.terra:terra-common-lib:0.0.66-SNAPSHOT'
 }
 
 tasks.named('test') {

--- a/service/src/main/java/bio/terra/policy/db/PaoDao.java
+++ b/service/src/main/java/bio/terra/policy/db/PaoDao.java
@@ -17,6 +17,7 @@ import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
@@ -38,6 +39,7 @@ public class PaoDao {
     this.tpsJdbcTemplate = new NamedParameterJdbcTemplate(tpsDatabaseConfiguration.getDataSource());
   }
 
+  @Retryable(interceptor = "transactionRetryInterceptor")
   @Transactional(
       isolation = Isolation.SERIALIZABLE,
       propagation = Propagation.REQUIRED,
@@ -92,6 +94,7 @@ public class PaoDao {
     }
   }
 
+  @Retryable(interceptor = "transactionRetryInterceptor")
   @Transactional(
       isolation = Isolation.SERIALIZABLE,
       propagation = Propagation.REQUIRED,
@@ -123,6 +126,7 @@ public class PaoDao {
     tpsJdbcTemplate.update(sql, params);
   }
 
+  @Retryable(interceptor = "transactionRetryInterceptor")
   @Transactional(
       isolation = Isolation.SERIALIZABLE,
       propagation = Propagation.REQUIRED,

--- a/service/src/main/resources/policydb/changelog.xml
+++ b/service/src/main/resources/policydb/changelog.xml
@@ -4,4 +4,5 @@
   <property name="uuid_function" value="gen_random_uuid()" dbms="postgresql"/>
 
   <include file="changesets/20220608_initial.yaml" relativeToChangelogFile="true"/>
+  <include file="changesets/20220811_attribute_set_index.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/service/src/main/resources/policydb/changesets/20220811_attribute_set_index.yaml
+++ b/service/src/main/resources/policydb/changesets/20220811_attribute_set_index.yaml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+  - changeSet:
+      id: attribute_set_index
+      author: dd
+      changes:
+      - createIndex:
+          indexName: attribute_set_id_index
+          tableName: attribute_set
+          unique: false
+          columns:
+            - column:
+                name: set_id

--- a/testharness/src/main/java/bio/terra/policy/app/Main.java
+++ b/testharness/src/main/java/bio/terra/policy/app/Main.java
@@ -19,6 +19,8 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
       "bio.terra.common.logging",
       // Scan for Liquibase migration components & configs
       "bio.terra.common.migrate",
+      // Transaction management and DB retry configuration
+      "bio.terra.common.retry.transaction",
       // Scan all policy service packages
       "bio.terra.policy",
     })


### PR DESCRIPTION
Two changes in this PR:
1. Add retry to the database transactions. This makes sure we don't just fail on a serialization error, but instead rerun the transaction.
2. Add an index to set_id in the attribute_set table. This should make serialization errors less likely. The table has no primary key, so there was no index. That meant every attribute set operation - like delete - would scan the entire table. With the index, there should be no row overlaps on the table operations.
