### PR TITLE
[PF-1634] Rename child/parent to source/dependent; add update processing

### DIFF
--- a/service/IMPLEMENTATION_NOTES.md
+++ b/service/IMPLEMENTATION_NOTES.md
@@ -1,13 +1,31 @@
 # Implementation Notes
 
-## Updating a PAO
+These implementation notes assume you are familiar with the
+[Policy Design](https://docs.google.com/document/d/1dRtE_nZf8e231DZmk_-9CDbjYTiIN2ZZwI95uF1w2pg/edit#heading=h.1uc5ubqdd419)
+
+## Updating a Policy Attribute Object (PAO)
 A PAO update is a proposed change to the attribute set of the PAO. The implementation needs to evaluate the effect
-of the change on the policy graph and, depending on the update mode (DRY_RUN, FAIL_ON_CONFLICT, ENFORCE_CONFLICT),
-make changes to the graph. Since the changes may be tossed, we need to build an in-memory structure of the PAOs.
+of the change on the policy graph and, depending on the update mode make changes to the graph.
 
-The graph is a DAG, but not a strict hierarchy; that is, we can have a graph that looks like this:
+The update mode can be:
+- DRY_RUN - evaluate the change, but do not apply it
+- FAIL_ON_CONFLICT - evaluate the change and apply it if there are no new conflicts
+- ENFORCE_CONFLICT - evaluate the change and apply it, annotating dependent PAOs as having a conflict.
+TPS does not define the semantics of what components do if their policy is in conflict.
 
-The pointers represent source-to-dependent links. Since, there may be multiple paths to the same dependent, we
+Since the evaluated changes may be tossed, we need to build an in-memory structure of the PAOs.
+The policy graph is a DAG, but not a strict hierarchy; that is, we can have a graph that looks like this:
+```
+  Pao:A --------------> Pao:C
+    |                     ^
+    |                     |
+     -------> Pao:B ------
+```
+The pointers represent source-to-dependent links. So Pao:B has Pao:A as a source.
+Pao:C has both Pao:A and Pao:B as sources. Or said the other way around,
+Pao:A has Pao:B and Pao:C as dependents. Pao:B has Pao:C as a dependent.
+
+Since there may be multiple paths to the same dependent, we
 could optimize by not re-evaluating a dependent that has already been evaluated. However, there is an implicit
 assumption in that optimization. Suppose a change to A results in a change to C. Now is there a way that a
 change to A results in a change to B that results in a different change to C? It seems unlikely, but if there
@@ -22,19 +40,33 @@ There are three elements to the memory model:
 
 ### Graph Node
 A graph node represents one PAO and its links to dependents and sources:
-- pao - the Pao object of interest
+- initial pao - the initial state of the Pao from the database
+- modified pao - the proposed modification of the Pao; but with an empty conflict set
 - dependents - list of dependent graph nodes
 - sources - list of source graph nodes
 - modified - boolean indicating the Pao has been modified
+- newConflict - a new conflict has been found 
 
 ### Pao Map
-This is a Map:
+This is an in-memory Map:
 - key - object id of a Pao
 - value - graph node
 
-We use the map in building out the graph, so that as we walk we are referring to mutated Paos and not the ones in the
-database. If we try a lookup in the map and it is not found, then we know we have to get it from the database
-and populate the map.
+As we walk the graph, we need to lookup source and dependent PAOs by object id. When we do that lookup we first
+look in the Pao Map to see if we have already read the PAO from the database. If it is not there, then we read
+from the database, build a graph node and add it to the Pao Map.
+
+We may revisit the same PAO multiple times in the graph walk. Those PAOs may have changes from the update.
+We want to be sure we are evaluating the update based on _updated_ PAOs and not the version in the database.
+
+### Policy Conflict List
+After a graph walk evaluating an update to a PAO, we make a pass through the Pao Map and see if we have
+found any new conflicts. If so:
+- We mark the graph node to ensure the PAO is viewed as modified
+- We collect the conflicts in a list to be reported back through the API
+
+**NOTE**: I am not confident that the current form of PolicyConflict is its final form. We will need
+feedback from TPS clients to tune it up.
 
 ## Building the Graph - Design Choice
 There is a design choice in how we build the graph. We could either build out the whole dependent graph and then do
@@ -59,17 +91,31 @@ may be linking a new source to the targetPao. We build a graph node for the targ
 launch the walk using targetNode as the inputNode:
 1. Populate the source list of the inputNode. We read the object ids from the inputNode and get the source graph nodes 
 from the Pao Map or by reading them from the database and constructing graph nodes for them.
-2. Compute the new effective attribute set for the inputPao. If there are conflicts, store them and mark the graph node.
+2. Compute the new effective attribute set for the inputPao by evaluating the modifiedPao of each source node.
+For each source node, for each policy input:
+    1. If the source policy input is not in the inputPao effective attribute set, then add it
+    2. If the source policy input is in the inputPao effective attribute set, then call the _combiner_ for the
+policy type. Store the result of that, and any conflicts from that combination, into the inputPao effective attribute set.
 3. If the new effective attributes are the same as the existing effective attributes, we are done.
-4. Otherwise, there is a change. Mark the graph node as modified. Walk the dependents:
-5. Populate the dependents list of the inputNode. We do a database query to find all dependents with this Pao as
+4. Otherwise, there is a change. Mark the graph node as modified. We need to propagate the modification to
+any dependents of this PAO. We walk the dependents like this:
+   1. Populate the dependents list of the inputNode. We do a database query to find all dependents with this Pao as
 a source. Then we either build new graph nodes or we use existing (possibly already modified) graph nodes in the Pao Map.
-6. For each dependent, recurse to step 1. We know that the current, modified graph node will be a source of the
+   2. For each dependent, recurse to step 1. We know that the current, modified graph node will be a source of the
 dependent, so will be considered in the computation of its new effective attribute set.
 
 The result is a depth-first graph walk, building out the dependent nodes as we walk, and marking the graph nodes
 that hold modified Paos. At this point we have a Pao map with graph nodes. The nodes are marked so we know if
-they have been modified and if they have new conflicts.
+they have been modified.
+
+Once the graph has been walked, we check for new conflicts. We iterate over the Pao Map looking at each
+graph node, and then iterate over the new effective attributes comparing their conflict list with the
+initial Pao conflict list. If they are different, we mark the graph node as having new conflicts. That
+ensures it is written back to the database even if there is no change to effective policies. We also
+mint a new PolicyConflict object and add it to the list; those are returned to the caller.
+
+**TODO**: Make sure that a policy change that _removes_ a conflict gets flagged for writing back, but does
+not generate a new PolicyConflict object. Maybe newConflict is a misnomer; it may just mean changed conflict.
 
 ## Performing the Update
 The update mode controls what we do next. In all cases we will return policy conflicts from the walk and discard

--- a/service/IMPLEMENTATION_NOTES.md
+++ b/service/IMPLEMENTATION_NOTES.md
@@ -1,0 +1,105 @@
+# Implementation Notes
+
+## Updating a PAO
+A PAO update is a proposed change to the attribute set of the PAO. The implementation needs to evaluate the effect
+of the change on the policy graph and, depending on the update mode (DRY_RUN, FAIL_ON_CONFLICT, ENFORCE_CONFLICT),
+make changes to the graph. Since the changes may be tossed, we need to build an in-memory structure of the PAOs.
+
+The graph is a DAG, but not a strict hierarchy; that is, we can have a graph that looks like this:
+
+The pointers represent source-to-dependent links. Since, there may be multiple paths to the same dependent, we
+could optimize by not re-evaluating a dependent that has already been evaluated. However, there is an implicit
+assumption in that optimization. Suppose a change to A results in a change to C. Now is there a way that a
+change to A results in a change to B that results in a different change to C? It seems unlikely, but if there
+are combinations of policy inputs that lead to different results, it could happen. Given the unpredictability
+of external policies, we should not take that optimization.
+
+The optimization we can take is: if the re-evaluation of C does not change its effective attributes, then we do not 
+need to continue to process its dependents. We would have done that on the initial evaluation.
+
+## Memory Model
+There are three elements to the memory model:
+
+### Graph Node
+A graph node represents one PAO and its links to dependents and sources:
+- pao - the Pao object of interest
+- dependents - list of dependent graph nodes
+- sources - list of source graph nodes
+- modified - boolean indicating the Pao has been modified
+
+### Pao Map
+This is a Map:
+- key - object id of a Pao
+- value - graph node
+
+We use the map in building out the graph, so that as we walk we are referring to mutated Paos and not the ones in the
+database. If we try a lookup in the map and it is not found, then we know we have to get it from the database
+and populate the map.
+
+## Building the Graph - Design Choice
+There is a design choice in how we build the graph. We could either build out the whole dependent graph and then do
+the walking or we could build it incrementally as we walk.
+
+Imagine a case where we the Pao update is adding a source. If the source does not change the Pao's effective
+attribute set, then there is no need to walk the dependents.
+That is probably a common case: the source has no policies set so there is no change.
+
+If the Pao is changed, what are the chances that change will need to propagate to all of the dependents?
+Or said another way, what are the chances that the dependents already have the policy set,
+so this change will have no effect? I don't know.
+
+There might be some advantage to reading everything from the database in one go.
+
+From the implementation point of view, I think it is easier to construct the graph during the recursive walk 
+rather than recurse once in the database and again in the walk.
+
+## Walking the Graph - The Algorithm
+Call the point of initial change the targetPao. The change may be an update to the targetPao's attribute set or it
+may be linking a new source to the targetPao. We build a graph node for the targetPao; call it the targetNode and
+launch the walk using targetNode as the inputNode:
+1. Populate the source list of the inputNode. We read the object ids from the inputNode and get the source graph nodes 
+from the Pao Map or by reading them from the database and constructing graph nodes for them.
+2. Compute the new effective attribute set for the inputPao. If there are conflicts, store them and mark the graph node.
+3. If the new effective attributes are the same as the existing effective attributes, we are done.
+4. Otherwise, there is a change. Mark the graph node as modified. Walk the dependents:
+5. Populate the dependents list of the inputNode. We do a database query to find all dependents with this Pao as
+a source. Then we either build new graph nodes or we use existing (possibly already modified) graph nodes in the Pao Map.
+6. For each dependent, recurse to step 1. We know that the current, modified graph node will be a source of the
+dependent, so will be considered in the computation of its new effective attribute set.
+
+The result is a depth-first graph walk, building out the dependent nodes as we walk, and marking the graph nodes
+that hold modified Paos. At this point we have a Pao map with graph nodes. The nodes are marked so we know if
+they have been modified and if they have new conflicts.
+
+## Performing the Update
+The update mode controls what we do next. In all cases we will return policy conflicts from the walk and discard
+the in-memory structures.
+
+If the update mode is FAIL_ON_CONFLICT and there are no conflicts, OR if the update mode is ENFORCE_CONFLICTS,
+then we will update the database.
+
+The database update is driven from the Pao Map. We can scan the entries and perform database updates for all
+graph nodes that have been modified. This update should happen in a single transaction, so we probably want
+to gather that list of modified Paos and ask the PaoDao to perform all of the updates.
+
+## Concurrency Control
+There are two approaches to concurrency control we could take.
+
+### Option 1: Big Transaction
+We could make a database transaction with the same scope as running the update algorithm. The database reads and update
+would all happen in the same transaction. That requires running the transaction outside of the DAO code and
+holding it open for the whole process.
+
+The potential problem with the big transaction approach is limiting concurrent policy transactions due to internal
+concurrency controls in Postgres. Unrelated policy updates could queue and be actually serialized in the database.
+
+### Option 2: Pao Versioning
+We could give each PAO in the database a monotonically increasing version number. Updating a PAO would mean reading
+the PAO and checking that the incoming version matches the current version; that is, no other changes happened.
+This is the same concept as etags in GCP ACLs.
+
+The potential problem with versioning is that it would allow a concurrent change, causing the update to fail and
+need to be redone.
+
+I think it is reasonable to start with the Big Transaction approach and let the database do its thing. If we
+experience concurrency issues from unrelated changes, then we can implement the versioning approach.

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -11,6 +11,12 @@ plugins {
 apply from: 'publishing.gradle'
 
 dependencies {
+    // Guava dependency
+    constraints {
+        implementation 'com.google.guava:guava:31.1-jre' // "-jre" for Java 8 or higher
+    }
+    implementation group: "com.google.guava", name:"guava"
+
     implementation 'bio.terra:terra-common-lib'
     implementation 'org.apache.commons:commons-dbcp2:2.9.0'
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc:2.7.0'

--- a/service/src/main/java/bio/terra/policy/common/model/PolicyInput.java
+++ b/service/src/main/java/bio/terra/policy/common/model/PolicyInput.java
@@ -1,27 +1,67 @@
 package bio.terra.policy.common.model;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 
 public class PolicyInput {
-  private final String namespace;
-  private final String name;
-  private final Map<String, String> additionalData;
+  private final PolicyName policyName;
+  private final Multimap<String, String> additionalData;
+  private final Set<UUID> conflicts;
 
-  public PolicyInput(String namespace, String name, Map<String, String> additionalData) {
-    this.namespace = namespace;
-    this.name = name;
+  public PolicyInput(
+      PolicyName policyName, Multimap<String, String> additionalData, Set<UUID> conflicts) {
+    this.policyName = policyName;
     this.additionalData = additionalData;
+    this.conflicts = conflicts;
   }
 
-  public String getNamespace() {
-    return namespace;
+  public PolicyInput(PolicyName policyName, Multimap<String, String> additionalData) {
+    this(policyName, additionalData, new HashSet<>());
   }
 
-  public String getName() {
-    return name;
+  public PolicyInput(String namespace, String name, Multimap<String, String> additionalData) {
+    this(new PolicyName(namespace, name), additionalData, new HashSet<>());
   }
 
-  public Map<String, String> getAdditionalData() {
+  // Handy constructor for the non-multimap uses
+  public static PolicyInput createFromMap(
+      String namespace, String name, Map<String, String> additionalData) {
+    // Convert the map to a multimap
+    Multimap<String, String> mm = ArrayListMultimap.create();
+    additionalData.entrySet().forEach(e -> mm.put(e.getKey(), e.getValue()));
+    return new PolicyInput(new PolicyName(namespace, name), mm, new HashSet<>());
+  }
+
+  public PolicyName getPolicyName() {
+    return policyName;
+  }
+
+  public String getPolicyNameKey() {
+    return policyName.getKey();
+  }
+
+  public String getKey() {
+    return policyName.getKey();
+  }
+
+  public Collection<String> getData(String key) {
+    return additionalData.get(key);
+  }
+
+  public Multimap<String, String> getAdditionalData() {
     return additionalData;
+  }
+
+  public Set<UUID> getConflicts() {
+    return conflicts;
+  }
+
+  public PolicyInput duplicateWithoutConflicts() {
+    return new PolicyInput(policyName, additionalData);
   }
 }

--- a/service/src/main/java/bio/terra/policy/common/model/PolicyInputs.java
+++ b/service/src/main/java/bio/terra/policy/common/model/PolicyInputs.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import javax.annotation.Nullable;
 
 /**
  * PolicyInputs provides a map of inputs. The key is composed as input.namespace + ":" + input.name.
@@ -15,21 +16,43 @@ public class PolicyInputs {
     this.inputs = inputs;
   }
 
+  public PolicyInputs() {
+    this.inputs = new HashMap<>();
+  }
+
+  public void addInput(PolicyInput input) {
+    inputs.put(input.getKey(), input);
+  }
+
+  /**
+   * Lookup a matching policy input given an incoming policy input
+   *
+   * @param input incoming policy input
+   * @return matching policy input or null if not found
+   */
+  public @Nullable PolicyInput lookupPolicy(PolicyInput input) {
+    return inputs.get(input.getKey());
+  }
+
   public Map<String, PolicyInput> getInputs() {
     return inputs;
   }
 
   public static PolicyInputs fromDb(List<PolicyInput> inputList) {
-    var inputs = new HashMap<String, PolicyInput>();
+    PolicyInputs inputs = new PolicyInputs();
     for (PolicyInput input : inputList) {
-      String key = composeKey(input.getNamespace(), input.getName());
-      inputs.put(key, input);
+      inputs.addInput(input);
     }
-    return new PolicyInputs(inputs);
+    return inputs;
   }
 
-  public static String composeKey(String namespace, String name) {
-    return namespace + ":" + name;
+  public PolicyInputs duplicateWithoutConflicts() {
+    Map<String, PolicyInput> dupMap = new HashMap<>();
+    for (var entry : inputs.entrySet()) {
+      var dupInput = entry.getValue().duplicateWithoutConflicts();
+      dupMap.put(entry.getKey(), dupInput);
+    }
+    return new PolicyInputs(dupMap);
   }
 
   @Override

--- a/service/src/main/java/bio/terra/policy/common/model/PolicyName.java
+++ b/service/src/main/java/bio/terra/policy/common/model/PolicyName.java
@@ -1,0 +1,42 @@
+package bio.terra.policy.common.model;
+
+import java.util.Objects;
+
+public class PolicyName {
+  private final String namespace;
+  private final String name;
+
+  public PolicyName(String namespace, String name) {
+    this.namespace = namespace;
+    this.name = name;
+  }
+
+  public String getKey() {
+    return composeKey(namespace, name);
+  }
+
+  public String getNamespace() {
+    return namespace;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public static String composeKey(String namespace, String name) {
+    return namespace + ":" + name;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof PolicyName)) return false;
+    PolicyName that = (PolicyName) o;
+    return Objects.equals(namespace, that.namespace) && Objects.equals(name, that.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(namespace, name);
+  }
+}

--- a/service/src/main/java/bio/terra/policy/db/DbAdditionalData.java
+++ b/service/src/main/java/bio/terra/policy/db/DbAdditionalData.java
@@ -14,7 +14,6 @@ import java.util.Map;
  */
 public class DbAdditionalData {
   private record DbDataPair(String key, String value) {}
-  ;
 
   private final List<DbDataPair> dataPairList;
 

--- a/service/src/main/java/bio/terra/policy/db/DbAdditionalData.java
+++ b/service/src/main/java/bio/terra/policy/db/DbAdditionalData.java
@@ -1,0 +1,47 @@
+package bio.terra.policy.db;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * We use Multimap for processing additional data in the Pao processing, but we cannot use it for
+ * database serdes. Instead, we use this intermediate form that is simpler to serialize.
+ */
+public class DbAdditionalData {
+  private record DbDataPair(String key, String value) {}
+  ;
+
+  private final List<DbDataPair> dataPairList;
+
+  @JsonCreator
+  public DbAdditionalData(@JsonProperty("dataPairList") List<DbDataPair> dataPairList) {
+    this.dataPairList = dataPairList;
+  }
+
+  public static Multimap<String, String> fromDb(String jsonString) {
+    DbAdditionalData data = DbSerDes.fromJson(jsonString, DbAdditionalData.class);
+    Multimap<String, String> mm = ArrayListMultimap.create();
+    for (DbDataPair pair : data.dataPairList) {
+      mm.put(pair.key(), pair.value());
+    }
+    return mm;
+  }
+
+  public static String toDb(Multimap<String, String> inData) {
+    List<DbDataPair> dataPairList = new ArrayList<>();
+    for (Map.Entry<String, String> entry : inData.entries()) {
+      dataPairList.add(new DbDataPair(entry.getKey(), entry.getValue()));
+    }
+    DbAdditionalData dbData = new DbAdditionalData(dataPairList);
+    return DbSerDes.toJson(dbData);
+  }
+
+  public List<DbDataPair> getDataPairList() {
+    return dataPairList;
+  }
+}

--- a/service/src/main/java/bio/terra/policy/db/DbAttribute.java
+++ b/service/src/main/java/bio/terra/policy/db/DbAttribute.java
@@ -1,0 +1,6 @@
+package bio.terra.policy.db;
+
+import bio.terra.policy.common.model.PolicyInput;
+
+/** Record to hold one attribute of an attribute set and its set id */
+public record DbAttribute(String setId, PolicyInput policyInput) {}

--- a/service/src/main/java/bio/terra/policy/db/DbPao.java
+++ b/service/src/main/java/bio/terra/policy/db/DbPao.java
@@ -2,6 +2,7 @@ package bio.terra.policy.db;
 
 import bio.terra.policy.service.pao.model.PaoComponent;
 import bio.terra.policy.service.pao.model.PaoObjectType;
+import java.util.Set;
 import java.util.UUID;
 
 /** Record to hold a PAO record when processing in the PaoDao */
@@ -9,6 +10,6 @@ public record DbPao(
     UUID objectId,
     PaoComponent component,
     PaoObjectType objectType,
-    boolean inConflict,
+    Set<String> sources,
     String attributeSetId,
     String effectiveSetId) {}

--- a/service/src/main/java/bio/terra/policy/db/DbSerDes.java
+++ b/service/src/main/java/bio/terra/policy/db/DbSerDes.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
-import java.util.Map;
+import com.google.common.collect.Multimap;
 
 /**
  * Object mapper for use in the DAO modules. This mapper must stay constant over time to ensure that
@@ -40,13 +40,13 @@ public class DbSerDes {
   }
 
   // Specific mappers for key-value properties
-  public static String propertiesToJson(Map<String, String> kvmap) {
+  public static String propertiesToJson(Multimap<String, String> kvmap) {
     return toJson(kvmap);
   }
 
-  public static Map<String, String> jsonToProperties(String json) {
+  public static Multimap<String, String> jsonToProperties(String json) {
     try {
-      return serdesMapper.readValue(json, new TypeReference<Map<String, String>>() {});
+      return serdesMapper.readValue(json, new TypeReference<Multimap<String, String>>() {});
     } catch (JsonProcessingException ex) {
       throw new SerializationException("Failed to deserialize properties", ex);
     }

--- a/service/src/main/java/bio/terra/policy/db/PaoDao.java
+++ b/service/src/main/java/bio/terra/policy/db/PaoDao.java
@@ -3,18 +3,28 @@ package bio.terra.policy.db;
 import bio.terra.policy.common.exception.PolicyObjectNotFoundException;
 import bio.terra.policy.common.model.PolicyInput;
 import bio.terra.policy.common.model.PolicyInputs;
+import bio.terra.policy.common.model.PolicyName;
 import bio.terra.policy.db.exception.DuplicateObjectException;
 import bio.terra.policy.library.configuration.TpsDatabaseConfiguration;
+import bio.terra.policy.service.pao.graph.model.GraphNode;
 import bio.terra.policy.service.pao.model.Pao;
 import bio.terra.policy.service.pao.model.PaoComponent;
 import bio.terra.policy.service.pao.model.PaoObjectType;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.retry.annotation.Retryable;
@@ -29,13 +39,38 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Component
 public class PaoDao {
+  private static final RowMapper<DbPao> DB_PAO_ROW_MAPPER =
+      (rs, rowNum) -> {
+        String[] sourcesArray = (String[]) rs.getArray("sources").getArray();
+        Set<String> sources = new HashSet<>(Arrays.asList(sourcesArray));
+        return new DbPao(
+            UUID.fromString(rs.getString("object_id")),
+            PaoComponent.fromDb(rs.getString("component")),
+            PaoObjectType.fromDb(rs.getString("object_type")),
+            sources,
+            rs.getString("attribute_set_id"),
+            rs.getString("effective_set_id"));
+      };
+
+  private static final RowMapper<DbAttribute> DB_ATTRIBUTE_SET_ROW_MAPPER =
+      (rs, rowNum) -> {
+        String[] conflictsArray = (String[]) rs.getArray("conflicts").getArray();
+        Set<UUID> conflicts =
+            Arrays.stream(conflictsArray).map(UUID::fromString).collect(Collectors.toSet());
+
+        return new DbAttribute(
+            rs.getString("set_id"),
+            new PolicyInput(
+                new PolicyName(rs.getString("namespace"), rs.getString("name")),
+                DbAdditionalData.fromDb(rs.getString("properties")),
+                conflicts));
+      };
+
   private final Logger logger = LoggerFactory.getLogger(PaoDao.class);
-  private final TpsDatabaseConfiguration tpsDatabaseConfiguration;
   private final NamedParameterJdbcTemplate tpsJdbcTemplate;
 
   @Autowired
   public PaoDao(TpsDatabaseConfiguration tpsDatabaseConfiguration) {
-    this.tpsDatabaseConfiguration = tpsDatabaseConfiguration;
     this.tpsJdbcTemplate = new NamedParameterJdbcTemplate(tpsDatabaseConfiguration.getDataSource());
   }
 
@@ -48,21 +83,27 @@ public class PaoDao {
       UUID objectId, PaoComponent component, PaoObjectType objectType, PolicyInputs inputs) {
 
     final String sql =
-        "INSERT INTO policy_object (object_id, component, object_type, children, in_conflict,"
-            + " attribute_set_id, effective_set_id)"
-            + " VALUES (:object_id, :component, :object_type, '{}', false,"
-            + " :attribute_set_id, :effective_set_id)";
+        """
+        INSERT INTO policy_object (object_id, component, object_type, sources, attribute_set_id, effective_set_id)
+        VALUES (:object_id, :component, :object_type, '{}', :attribute_set_id, :effective_set_id)
+        """;
 
-    final String setId = UUID.randomUUID().toString();
+    // Store the attribute set twice: once as the object's set and once as its effective set.
+    // We could optimize this case, but the logic is cleaner if we treat them distinctly from the
+    // outset.
+    String attributeSetId = UUID.randomUUID().toString();
+    String effectiveSetId = UUID.randomUUID().toString();
+    createAttributeSet(attributeSetId, inputs);
+    createAttributeSet(effectiveSetId, inputs);
 
-    // First we store the policy object with a "forward reference" to the set.
+    // Store the policy object pointing both attribute and effective to the same attribute set
     MapSqlParameterSource params =
         new MapSqlParameterSource()
             .addValue("object_id", objectId.toString())
             .addValue("component", component.getDbComponent())
             .addValue("object_type", objectType.getDbObjectType())
-            .addValue("attribute_set_id", setId)
-            .addValue("effective_set_id", setId);
+            .addValue("attribute_set_id", attributeSetId)
+            .addValue("effective_set_id", effectiveSetId);
 
     try {
       tpsJdbcTemplate.update(sql, params);
@@ -70,27 +111,6 @@ public class PaoDao {
     } catch (DuplicateKeyException e) {
       throw new DuplicateObjectException(
           "Duplicate policy attributes object with objectId " + objectId);
-    }
-
-    // Second we store the policy inputs
-    final String setsql =
-        "INSERT INTO attribute_set(set_id, namespace, name, properties)"
-            + " VALUES(:set_id, :namespace, :name, cast(:properties AS jsonb))";
-
-    for (PolicyInput input : inputs.getInputs().values()) {
-      MapSqlParameterSource setparams =
-          new MapSqlParameterSource()
-              .addValue("set_id", setId)
-              .addValue("namespace", input.getNamespace())
-              .addValue("name", input.getName())
-              .addValue("properties", DbSerDes.propertiesToJson(input.getAdditionalData()));
-
-      tpsJdbcTemplate.update(setsql, setparams);
-      logger.info(
-          "Inserted record for pao set id {}, namespace {}, name {}",
-          setId,
-          input.getNamespace(),
-          input.getName());
     }
   }
 
@@ -106,9 +126,7 @@ public class PaoDao {
 
       // Delete associated attribute set(s)
       deleteAttributeSet(dbPao.attributeSetId());
-      if (!dbPao.attributeSetId().equals(dbPao.effectiveSetId())) {
-        deleteAttributeSet(dbPao.effectiveSetId());
-      }
+      deleteAttributeSet(dbPao.effectiveSetId());
 
       // Delete the policy object
       final String sql = "DELETE FROM policy_object WHERE object_id = :object_id";
@@ -120,12 +138,6 @@ public class PaoDao {
     }
   }
 
-  private void deleteAttributeSet(String setId) {
-    final String sql = "DELETE FROM attribute_set WHERE set_id = :set_id";
-    final var params = new MapSqlParameterSource().addValue("set_id", setId);
-    tpsJdbcTemplate.update(sql, params);
-  }
-
   @Retryable(interceptor = "transactionRetryInterceptor")
   @Transactional(
       isolation = Isolation.SERIALIZABLE,
@@ -135,65 +147,243 @@ public class PaoDao {
   public Pao getPao(UUID objectId) {
     try {
       DbPao dbPao = getDbPao(objectId);
-      PolicyInputs attributeSet = getAttributeSet(dbPao.attributeSetId());
-      PolicyInputs effectiveSet;
-      if (dbPao.attributeSetId().equals(dbPao.effectiveSetId())) {
-        effectiveSet = attributeSet;
-      } else {
-        effectiveSet = getAttributeSet(dbPao.effectiveSetId());
-      }
+      Map<String, PolicyInputs> attributeSetMap =
+          getAttributeSets(List.of(dbPao.attributeSetId(), dbPao.effectiveSetId()));
+
       return new Pao.Builder()
           .setObjectId(dbPao.objectId())
           .setComponent(dbPao.component())
           .setObjectType(dbPao.objectType())
-          .setAttributes(attributeSet)
-          .setEffectiveAttributes(effectiveSet)
-          .setInConflict(dbPao.inConflict())
+          .setAttributes(attributeSetMap.get(dbPao.attributeSetId()))
+          .setEffectiveAttributes(attributeSetMap.get(dbPao.effectiveSetId()))
           .build();
     } catch (EmptyResultDataAccessException e) {
       throw new PolicyObjectNotFoundException("Policy object not found: " + objectId);
     }
   }
 
+  // -- Graph Walk Methods --
+  // These methods are intentionally without transaction annotations. They are used by the policy
+  // update
+  // process. That process may do multiple reads of the database followed by a big update. The
+  // transaction
+  // is managed outside of the DAO.
+
+  /**
+   * Given a list of PAO ids, return PAOs
+   *
+   * @param objectIdList UUIDs of Policy Attribute Objects
+   * @return List of Pao objects
+   */
+  public List<Pao> getPaos(List<UUID> objectIdList) {
+    List<DbPao> dbPaoList = getDbPaos(objectIdList);
+    List<String> setIdList = new ArrayList<>();
+    for (DbPao dbPao : dbPaoList) {
+      setIdList.add(dbPao.attributeSetId());
+      setIdList.add(dbPao.effectiveSetId());
+    }
+
+    // Gather all of the attribute sets
+    Map<String, PolicyInputs> attributeSetMap = getAttributeSets(setIdList);
+
+    List<Pao> paoList = new ArrayList<>();
+    for (DbPao dbPao : dbPaoList) {
+      paoList.add(
+          new Pao.Builder()
+              .setObjectId(dbPao.objectId())
+              .setComponent(dbPao.component())
+              .setObjectType(dbPao.objectType())
+              .setAttributes(attributeSetMap.get(dbPao.attributeSetId()))
+              .setEffectiveAttributes(attributeSetMap.get(dbPao.effectiveSetId()))
+              .build());
+    }
+
+    return paoList;
+  }
+
+  /**
+   * Given a source id, find all of the dependents and return their ids
+   *
+   * @param sourceId source to hunt for
+   * @return Set of dependent UUIDs that reference that source
+   */
+  public Set<UUID> getDependentIds(UUID sourceId) {
+    final String sql = "SELECT object_id FROM policy_object WHERE ARRAY[:source_id] <@ sources";
+
+    MapSqlParameterSource params =
+        new MapSqlParameterSource().addValue("source_id", sourceId.toString());
+
+    return new HashSet<>(
+        tpsJdbcTemplate.query(
+            sql, params, (rs, rowNum) -> UUID.fromString(rs.getString("object_id"))));
+  }
+
+  /**
+   * Update all of the changed Paos by processing the graph nodes. We use the graph nodes because
+   * they hold the initial version of the Pao and the computed version of the Pao, so we can update
+   * only what changed.
+   *
+   * @param changeList list of modified paos in graph nodes
+   */
+  public void updatePaos(List<GraphNode> changeList) {
+    changeList.forEach(this::updatePao);
+  }
+
+  /**
+   * Update one Pao if attribute set changed: rewrite attribute set if effective set changed:
+   * rewrite effective set if sources list changed, update the policy object with new sources array
+   *
+   * @param change graph node that has the initial and newly computed Paos
+   */
+  private void updatePao(GraphNode change) {
+    Pao initialPao = change.getInitialPao();
+    Pao computedPao = change.getComputePao();
+    DbPao initialDbPao = getDbPao(initialPao.getObjectId());
+
+    if (!initialPao.getAttributes().equals(computedPao.getAttributes())) {
+      String attributeSetId = initialDbPao.attributeSetId();
+      deleteAttributeSet(attributeSetId);
+      createAttributeSet(attributeSetId, computedPao.getAttributes());
+    }
+
+    if (!initialPao.getEffectiveAttributes().equals(computedPao.getEffectiveAttributes())) {
+      String effectiveSetId = initialDbPao.effectiveSetId();
+      deleteAttributeSet(effectiveSetId);
+      createAttributeSet(effectiveSetId, computedPao.getEffectiveAttributes());
+    }
+
+    if (!initialPao.getSourceObjectIds().equals(computedPao.getSourceObjectIds())) {
+      final String sql =
+          "UPDATE policy_object SET sources = string_to_array(:sources, ',') WHERE object_id = :object_id";
+
+      String sourcesSqlArray = makeCsvFromUuidSet(computedPao.getSourceObjectIds());
+
+      MapSqlParameterSource params =
+          new MapSqlParameterSource()
+              .addValue("object_id", initialPao.getObjectId().toString())
+              .addValue("sources", sourcesSqlArray);
+
+      tpsJdbcTemplate.update(sql, params);
+      logger.info(
+          "Update sources array for pao object id {}, sources {}",
+          initialPao.getObjectId().toString(),
+          sourcesSqlArray);
+    }
+  }
+
+  /**
+   * The JdbcTemplate doesn't have a nice way to pass arrays into and out of Postgres. Since we use
+   * UUIDs, we know there are no commas, so we can build the CSV and use the Postgres
+   * string_to_array builtin to set the array value.
+   *
+   * @param uuidSet input set of UUIDs
+   * @return csv of strings
+   */
+  private String makeCsvFromUuidSet(Set<UUID> uuidSet) {
+    return String.join(",", uuidSet.stream().map(UUID::toString).toList());
+  }
+
+  private void createAttributeSet(String setId, PolicyInputs inputs) {
+    final String setsql =
+        """
+        INSERT INTO attribute_set(set_id, namespace, name, properties, conflicts)
+        VALUES(:set_id, :namespace, :name, cast(:properties AS jsonb), string_to_array(:conflicts,','))
+        """;
+
+    for (PolicyInput input : inputs.getInputs().values()) {
+      String conflictCsv = makeCsvFromUuidSet(input.getConflicts());
+      MapSqlParameterSource setparams =
+          new MapSqlParameterSource()
+              .addValue("set_id", setId)
+              .addValue("namespace", input.getPolicyName().getNamespace())
+              .addValue("name", input.getPolicyName().getName())
+              .addValue("properties", DbAdditionalData.toDb(input.getAdditionalData()))
+              .addValue("conflicts", conflictCsv);
+      tpsJdbcTemplate.update(setsql, setparams);
+      logger.info(
+          "Inserted record for pao set id {}, policy {}, conflicts {}",
+          setId,
+          input.getPolicyName(),
+          conflictCsv);
+    }
+  }
+
+  private void deleteAttributeSet(String setId) {
+    final String sql = "DELETE FROM attribute_set WHERE set_id = :set_id";
+    final var params = new MapSqlParameterSource().addValue("set_id", setId);
+    tpsJdbcTemplate.update(sql, params);
+  }
+
   private DbPao getDbPao(UUID objectId) {
     final String sql =
-        "SELECT object_id, component, object_type, in_conflict, attribute_set_id, effective_set_id"
-            + " FROM policy_object WHERE object_id = :object_id";
+        """
+        SELECT object_id, component, object_type, attribute_set_id, effective_set_id, sources
+        FROM policy_object WHERE object_id = :object_id
+        """;
 
     MapSqlParameterSource params =
         new MapSqlParameterSource().addValue("object_id", objectId.toString());
 
-    return tpsJdbcTemplate.queryForObject(
-        sql,
-        params,
-        (rs, rowNum) -> {
-          return new DbPao(
-              UUID.fromString(rs.getString("object_id")),
-              PaoComponent.fromDb(rs.getString("component")),
-              PaoObjectType.fromDb(rs.getString("object_type")),
-              rs.getBoolean("in_conflict"),
-              rs.getString("attribute_set_id"),
-              rs.getString("effective_set_id"));
-        });
+    return tpsJdbcTemplate.queryForObject(sql, params, DB_PAO_ROW_MAPPER);
   }
 
-  private PolicyInputs getAttributeSet(String setId) {
+  private List<DbPao> getDbPaos(List<UUID> objectIdList) {
     final String sql =
-        "SELECT namespace, name, properties FROM attribute_set WHERE set_id = :set_id";
+        """
+        SELECT object_id, component, object_type, attribute_set_id, effective_set_id, sources
+        FROM policy_object
+        WHERE object_id IN (:object_id_list)
+        """;
 
-    final var params = new MapSqlParameterSource().addValue("set_id", setId);
+    MapSqlParameterSource params =
+        new MapSqlParameterSource().addValue("object_id_list", objectIdList);
 
-    List<PolicyInput> inputList =
-        tpsJdbcTemplate.query(
-            sql,
-            params,
-            (rs, rowNum) -> {
-              return new PolicyInput(
-                  rs.getString("namespace"),
-                  rs.getString("name"),
-                  DbSerDes.jsonToProperties(rs.getString("properties")));
-            });
+    return tpsJdbcTemplate.query(sql, params, DB_PAO_ROW_MAPPER);
+  }
 
-    return PolicyInputs.fromDb(inputList);
+  /**
+   * Build attribute sets from a list of set ids, possibly duplicate ones.
+   *
+   * @param setIdList list of set ids
+   * @return map of set id to attribute set
+   */
+  private Map<String, PolicyInputs> getAttributeSets(List<String> setIdList) {
+    final String sql =
+        """
+        SELECT set_id, namespace, name, properties, conflicts
+        FROM attribute_set
+        WHERE set_id IN (:set_id_list)
+        ORDER BY set_id
+        """;
+
+    var uniqueSetIds = new HashSet<>(setIdList);
+    var params = new MapSqlParameterSource().addValue("set_id_list", uniqueSetIds);
+
+    List<DbAttribute> attributeList =
+        tpsJdbcTemplate.query(sql, params, DB_ATTRIBUTE_SET_ROW_MAPPER);
+
+    var attributeSets = new HashMap<String, PolicyInputs>();
+    if (attributeList.isEmpty()) {
+      return attributeSets;
+    }
+
+    // We rely on the set_id order to properly split the resulting of attributes into their
+    // attribute sets
+    String currentSetId = attributeList.get(0).setId();
+    List<PolicyInput> inputList = new ArrayList<>();
+    for (DbAttribute attribute : attributeList) {
+      // If we are switching sets, finish the current one and start the next one
+      if (!attribute.setId().equals(currentSetId)) {
+        attributeSets.put(currentSetId, PolicyInputs.fromDb(inputList));
+        currentSetId = attribute.setId();
+        inputList = new ArrayList<>();
+      }
+      // Add this attribute to the current collection
+      inputList.add(attribute.policyInput());
+    }
+    // Finish the last set
+    attributeSets.put(currentSetId, PolicyInputs.fromDb(inputList));
+
+    return attributeSets;
   }
 }

--- a/service/src/main/java/bio/terra/policy/service/pao/PaoService.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/PaoService.java
@@ -77,6 +77,8 @@ public class PaoService {
     }
 
     // Build a copy of the Pao with the desired change
+    // We duplicate the target Pao, but we do not copy the conflict annotations.
+    // That way we can detect new conflicts and when conflicts are resolved.
     Pao targetPao = paoDao.getPao(objectId);
     Pao modifiedPao = targetPao.duplicateWithoutConflicts();
     modifiedPao.getSourceObjectIds().add(sourceObjectId);
@@ -97,10 +99,4 @@ public class PaoService {
 
     return new LinkSourceResult(modifiedPao, conflicts);
   }
-
-  public void updatePao(
-      UUID targetPaoId,
-      PolicyInputs addAttributes,
-      PolicyInputs removeAttributes,
-      PaoUpdateMode updateMode) {}
 }

--- a/service/src/main/java/bio/terra/policy/service/pao/PaoService.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/PaoService.java
@@ -16,7 +16,11 @@ import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 public class PaoService {
@@ -61,6 +65,11 @@ public class PaoService {
    * @param sourceObjectId id of the source object
    * @param updateMode link mode: fail on conflict or dry_run
    */
+  @Retryable(interceptor = "transactionRetryInterceptor")
+  @Transactional(
+      isolation = Isolation.SERIALIZABLE,
+      propagation = Propagation.REQUIRED,
+      transactionManager = "tpsTransactionManager")
   public LinkSourceResult linkSourcePao(
       UUID objectId, UUID sourceObjectId, PaoUpdateMode updateMode) {
     if (updateMode == PaoUpdateMode.ENFORCE_CONFLICTS) {

--- a/service/src/main/java/bio/terra/policy/service/pao/PaoService.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/PaoService.java
@@ -1,10 +1,17 @@
 package bio.terra.policy.service.pao;
 
+import bio.terra.policy.common.exception.InternalTpsErrorException;
 import bio.terra.policy.common.model.PolicyInputs;
 import bio.terra.policy.db.PaoDao;
+import bio.terra.policy.service.pao.graph.Walker;
+import bio.terra.policy.service.pao.graph.model.PolicyConflict;
 import bio.terra.policy.service.pao.model.Pao;
 import bio.terra.policy.service.pao.model.PaoComponent;
 import bio.terra.policy.service.pao.model.PaoObjectType;
+import bio.terra.policy.service.pao.model.PaoUpdateMode;
+import bio.terra.policy.service.policy.model.LinkSourceResult;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,4 +52,46 @@ public class PaoService {
     logger.info("Get PAO id {}", objectId);
     return paoDao.getPao(objectId);
   }
+
+  /**
+   * Link a policy source to a PAO. For example, referencing a data collection in a workspace would
+   * add the data collection as a policy source of the workspace.
+   *
+   * @param objectId id of the parent object
+   * @param sourceObjectId id of the source object
+   * @param updateMode link mode: fail on conflict or dry_run
+   */
+  public LinkSourceResult linkSourcePao(
+      UUID objectId, UUID sourceObjectId, PaoUpdateMode updateMode) {
+    if (updateMode == PaoUpdateMode.ENFORCE_CONFLICTS) {
+      throw new InternalTpsErrorException("ENFORCE_CONFLICTS is not allowed on listSourcePao");
+    }
+
+    // Build a copy of the Pao with the desired change
+    Pao targetPao = paoDao.getPao(objectId);
+    Pao modifiedPao = targetPao.duplicateWithoutConflicts();
+    modifiedPao.getSourceObjectIds().add(sourceObjectId);
+
+    // If nothing has actually changed, we are done
+    if (modifiedPao.getSourceObjectIds().equals(targetPao.getSourceObjectIds())) {
+      return new LinkSourceResult(targetPao, new ArrayList<>());
+    }
+
+    // Evaluate the change, calculating new effective attribute sets and finding conflicts
+    Walker walker = new Walker(paoDao, targetPao, modifiedPao);
+    List<PolicyConflict> conflicts = walker.walk();
+
+    // If the mode is FAIL_ON_CONFLICT and there are no conflicts, apply the changes
+    if (updateMode == PaoUpdateMode.FAIL_ON_CONFLICT && conflicts.isEmpty()) {
+      walker.applyChanges();
+    }
+
+    return new LinkSourceResult(modifiedPao, conflicts);
+  }
+
+  public void updatePao(
+      UUID targetPaoId,
+      PolicyInputs addAttributes,
+      PolicyInputs removeAttributes,
+      PaoUpdateMode updateMode) {}
 }

--- a/service/src/main/java/bio/terra/policy/service/pao/graph/Walker.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/graph/Walker.java
@@ -68,7 +68,7 @@ public class Walker {
     Pao inputPao = inputNode.getComputePao();
     PolicyInputs runningEffectiveSet = inputPao.getEffectiveAttributes();
     for (GraphNode source : inputNode.getSources()) {
-      runningEffectiveSet = computeEffective(runningEffectiveSet, inputNode, source);
+      runningEffectiveSet = computeEffective(runningEffectiveSet, source);
     }
 
     // If there is no change to the input effective attribute set, then we stop recursing.
@@ -90,26 +90,25 @@ public class Walker {
     }
   }
 
-  private PolicyInputs computeEffective(
-      PolicyInputs dependentInputs, GraphNode inputNode, GraphNode sourceNode) {
+  private PolicyInputs computeEffective(PolicyInputs dependentInputs, GraphNode sourceNode) {
     PolicyInputs newDependentEffective = new PolicyInputs();
     PolicyInputs sourceInputs = sourceNode.getComputePao().getEffectiveAttributes();
 
     // First traverse the input and probe the source. We take care of all combining
     // in this pass.
-    for (PolicyInput input : dependentInputs.getInputs().values()) {
-      PolicyInput sourceInput = sourceInputs.lookupPolicy(input);
+    for (PolicyInput dependentInput : dependentInputs.getInputs().values()) {
+      PolicyInput sourceInput = sourceInputs.lookupPolicy(dependentInput);
       if (sourceInput == null) {
-        newDependentEffective.addInput(input);
+        newDependentEffective.addInput(dependentInput);
       } else {
-        PolicyInput resultInput = PolicyCombiner.combine(input, sourceInput);
+        PolicyInput resultInput = PolicyCombiner.combine(dependentInput, sourceInput);
         if (resultInput == null) {
           // Combiner failed, so we have a conflict. Record the conflict in the input's
           // conflict set. Use the existing dependent input as the effective policy; that is,
           // when there is a conflict, we retain the existing policy setting and remember
           // the conflict.
-          input.getConflicts().add(sourceNode.getComputePao().getObjectId());
-          newDependentEffective.addInput(input);
+          dependentInput.getConflicts().add(sourceNode.getComputePao().getObjectId());
+          newDependentEffective.addInput(dependentInput);
         } else {
           newDependentEffective.addInput(resultInput);
         }

--- a/service/src/main/java/bio/terra/policy/service/pao/graph/Walker.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/graph/Walker.java
@@ -1,0 +1,227 @@
+package bio.terra.policy.service.pao.graph;
+
+import bio.terra.policy.common.model.PolicyInput;
+import bio.terra.policy.common.model.PolicyInputs;
+import bio.terra.policy.db.PaoDao;
+import bio.terra.policy.service.pao.graph.model.GraphNode;
+import bio.terra.policy.service.pao.graph.model.PolicyConflict;
+import bio.terra.policy.service.pao.model.Pao;
+import bio.terra.policy.service.policy.PolicyCombiner;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * We make a Walker class each time we need to perform a graph walk. It encapsulates the entire
+ * walking structure and returns the results. It calls the DAO, but has no transaction controls.
+ */
+public class Walker {
+  private final PaoDao paoDao;
+  private final Map<UUID, GraphNode> paoMap;
+  private final Pao initialPao;
+  private final Pao modifiedPao;
+
+  public Walker(PaoDao paoDao, Pao initialPao, Pao modifiedPao) {
+    this.paoDao = paoDao;
+    this.paoMap = new HashMap<>();
+    this.initialPao = initialPao;
+    this.modifiedPao = modifiedPao;
+  }
+
+  public void applyChanges() {
+    List<GraphNode> changeList = new ArrayList<>();
+    for (GraphNode node : paoMap.values()) {
+      // If we hit a conflict and there wasn't one before, or we modified the effective
+      // attribute set, then we need to update the Pao.
+      if (node.isNewConflict() || node.isModified()) {
+        changeList.add(node);
+      }
+    }
+    paoDao.updatePaos(changeList);
+  }
+
+  /**
+   * Recursively walk the policy graph building a map of modified Paos and a list of the conflicts
+   * caused by the modified policy.
+   *
+   * @return list of policy conflicts
+   */
+  public List<PolicyConflict> walk() {
+    var targetNode =
+        new GraphNode()
+            .setInitialPao(initialPao)
+            .setComputePao(modifiedPao)
+            .setModified(true)
+            .setNewConflict(false);
+    paoMap.put(modifiedPao.getObjectId(), targetNode);
+    walkNode(targetNode);
+    return computeConflict();
+  }
+
+  private void walkNode(GraphNode inputNode) {
+    makeSourcesList(inputNode);
+
+    // We compute the new effective attribute set from our sources
+    Pao inputPao = inputNode.getComputePao();
+    PolicyInputs runningEffectiveSet = inputPao.getEffectiveAttributes();
+    for (GraphNode source : inputNode.getSources()) {
+      runningEffectiveSet = computeEffective(runningEffectiveSet, inputNode, source);
+    }
+
+    // If there is no change to the input effective attribute set, then we stop recursing.
+    // We will not cause a change in any of our dependents. We still might have a conflict.
+    if (runningEffectiveSet.equals(inputPao.getEffectiveAttributes())) {
+      return;
+    }
+
+    // There was a change, so we have more work to do.
+    // Save the changes and mark us as changed.
+    inputPao.setEffectiveAttributes(runningEffectiveSet);
+    inputNode.setModified(true);
+
+    // Recursively walk our dependents. We know that these dependents will
+    // refer to this changed node in recalculating their effective attribute set.
+    makeDependentsList(inputNode);
+    for (GraphNode dependent : inputNode.getDependents()) {
+      walkNode(dependent);
+    }
+  }
+
+  private PolicyInputs computeEffective(
+      PolicyInputs dependentInputs, GraphNode inputNode, GraphNode sourceNode) {
+    PolicyInputs newDependentEffective = new PolicyInputs();
+    PolicyInputs sourceInputs = sourceNode.getComputePao().getEffectiveAttributes();
+
+    // First traverse the input and probe the source. We take care of all combining
+    // in this pass.
+    for (PolicyInput input : dependentInputs.getInputs().values()) {
+      PolicyInput sourceInput = sourceInputs.lookupPolicy(input);
+      if (sourceInput == null) {
+        newDependentEffective.addInput(input);
+      } else {
+        PolicyInput resultInput = PolicyCombiner.combine(input, sourceInput);
+        if (resultInput == null) {
+          // Combiner failed, so we have a conflict. Record the conflict in the input's
+          // conflict set. Use the existing dependent input as the effective policy; that is,
+          // when there is a conflict, we retain the existing policy setting and remember
+          // the conflict.
+          input.getConflicts().add(sourceNode.getComputePao().getObjectId());
+          newDependentEffective.addInput(input);
+        } else {
+          newDependentEffective.addInput(resultInput);
+        }
+      }
+    }
+
+    // Second traverse the source and probe the dependents. Add any non-matches and ignore the rest
+    for (PolicyInput input : sourceInputs.getInputs().values()) {
+      PolicyInput dependentInput = dependentInputs.lookupPolicy(input);
+      if (dependentInput == null) {
+        newDependentEffective.addInput(input);
+      }
+    }
+
+    return newDependentEffective;
+  }
+
+  private void makeSourcesList(GraphNode node) {
+    // If we already have the sources, do nothing
+    if (node.getSources() != null) {
+      return;
+    }
+    List<GraphNode> sources = makeGraphList(node.getComputePao().getSourceObjectIds());
+    node.setSources(sources);
+  }
+
+  private void makeDependentsList(GraphNode node) {
+    // If we already have the dependents, do nothing
+    if (node.getDependents() != null) {
+      return;
+    }
+    Set<UUID> dependentIds = paoDao.getDependentIds(node.getComputePao().getObjectId());
+    List<GraphNode> dependents = makeGraphList(dependentIds);
+    node.setDependents(dependents);
+  }
+
+  private List<GraphNode> makeGraphList(Set<UUID> idList) {
+    List<GraphNode> graphList = new ArrayList<>();
+    List<UUID> daoFetchIds = new ArrayList<>();
+    // Check the map; if the node is found in our map, add it to the result list.
+    // If not, add it to the to-be-fetched from the database list.
+    for (UUID id : idList) {
+      GraphNode foundNode = paoMap.get(id);
+      if (foundNode == null) {
+        daoFetchIds.add(id);
+      } else {
+        graphList.add(foundNode);
+      }
+    }
+
+    // Fetch the Paos that were not in the map; make graph nodes and add them to the map.
+    // New nodes always start without conflicts and unmodified.
+    List<Pao> daoFetchResult = paoDao.getPaos(daoFetchIds);
+    for (Pao pao : daoFetchResult) {
+      var node =
+          new GraphNode()
+              .setInitialPao(pao)
+              .setComputePao(pao.duplicateWithoutConflicts())
+              .setModified(false)
+              .setNewConflict(false);
+      graphList.add(node);
+      paoMap.put(pao.getObjectId(), node);
+    }
+    return graphList;
+  }
+
+  /**
+   * Make a pass through the graph checking to see if the evaluation of the change caused any new
+   * conflicts. Return the list of conflicts, if any.
+   *
+   * @return conflictList
+   */
+  private List<PolicyConflict> computeConflict() {
+    List<PolicyConflict> conflictList = new ArrayList<>();
+    for (GraphNode node : paoMap.values()) {
+      if (computeNodeConflict(node, conflictList)) {
+        node.setNewConflict(true);
+      }
+    }
+    return conflictList;
+  }
+
+  private boolean computeNodeConflict(GraphNode node, List<PolicyConflict> conflicts) {
+    // If the node is not modified, there is nothing to do
+    if (!node.isModified()) {
+      return false;
+    }
+
+    boolean foundNewConflicts = false;
+    PolicyInputs initialInputs = node.getInitialPao().getEffectiveAttributes();
+    PolicyInputs modifiedInputs = node.getComputePao().getEffectiveAttributes();
+
+    for (var entry : modifiedInputs.getInputs().entrySet()) {
+      PolicyInput initialInput = initialInputs.getInputs().get(entry.getKey());
+      // If there is no existing matching policy, there can be no conflict
+      if (initialInput == null) {
+        continue;
+      }
+      Set<UUID> initialConflicts = initialInput.getConflicts();
+      Set<UUID> newConflicts = entry.getValue().getConflicts();
+      for (var conflictId : newConflicts) {
+        // If the conflict is new - not in the initial state - then we mark the node
+        if (!initialConflicts.contains(conflictId)) {
+          conflicts.add(
+              new PolicyConflict(
+                  node.getComputePao(),
+                  paoMap.get(conflictId).getComputePao(),
+                  initialInput.getPolicyName()));
+          foundNewConflicts = true;
+        }
+      }
+    }
+    return foundNewConflicts;
+  }
+}

--- a/service/src/main/java/bio/terra/policy/service/pao/graph/model/GraphNode.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/graph/model/GraphNode.java
@@ -1,0 +1,67 @@
+package bio.terra.policy.service.pao.graph.model;
+
+import bio.terra.policy.service.pao.model.Pao;
+import java.util.List;
+
+public class GraphNode {
+  private Pao initialPao; // starting Pao - typically from the database
+  private Pao computePao; // Pao being computed in the graph walk
+  private List<GraphNode> sources;
+  private List<GraphNode> dependents;
+  private boolean modified; // true means something has been changed
+  private boolean newConflict; // true means we have computed a new conflict
+
+  public Pao getInitialPao() {
+    return initialPao;
+  }
+
+  public GraphNode setInitialPao(Pao initialPao) {
+    this.initialPao = initialPao;
+    return this;
+  }
+
+  public Pao getComputePao() {
+    return computePao;
+  }
+
+  public GraphNode setComputePao(Pao computePao) {
+    this.computePao = computePao;
+    return this;
+  }
+
+  public List<GraphNode> getSources() {
+    return sources;
+  }
+
+  public GraphNode setSources(List<GraphNode> sources) {
+    this.sources = sources;
+    return this;
+  }
+
+  public List<GraphNode> getDependents() {
+    return dependents;
+  }
+
+  public GraphNode setDependents(List<GraphNode> dependents) {
+    this.dependents = dependents;
+    return this;
+  }
+
+  public boolean isModified() {
+    return modified;
+  }
+
+  public GraphNode setModified(boolean modified) {
+    this.modified = modified;
+    return this;
+  }
+
+  public boolean isNewConflict() {
+    return newConflict;
+  }
+
+  public GraphNode setNewConflict(boolean newConflict) {
+    this.newConflict = newConflict;
+    return this;
+  }
+}

--- a/service/src/main/java/bio/terra/policy/service/pao/graph/model/GraphNode.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/graph/model/GraphNode.java
@@ -8,8 +8,9 @@ public class GraphNode {
   private Pao computePao; // Pao being computed in the graph walk
   private List<GraphNode> sources;
   private List<GraphNode> dependents;
-  private boolean modified; // true means something has been changed
-  private boolean newConflict; // true means we have computed a new conflict
+  private boolean modified; // true means something has been changed; false means no change
+  private boolean
+      newConflict; // true means we have computed a new conflict; false means no new conflict
 
   public Pao getInitialPao() {
     return initialPao;

--- a/service/src/main/java/bio/terra/policy/service/pao/graph/model/PolicyConflict.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/graph/model/PolicyConflict.java
@@ -1,0 +1,11 @@
+package bio.terra.policy.service.pao.graph.model;
+
+import bio.terra.policy.common.model.PolicyName;
+import bio.terra.policy.service.pao.model.Pao;
+
+/**
+ * Hold a policy conflict from the graph walk. The dependent is the updated dependent Pao based on
+ * the proposed update source. The source is the proposed updated source. The policyName is the name
+ * of the policy that has the conflict between the two.
+ */
+public record PolicyConflict(Pao dependent, Pao source, PolicyName policyName) {}

--- a/service/src/main/java/bio/terra/policy/service/pao/model/Pao.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/model/Pao.java
@@ -1,18 +1,18 @@
 package bio.terra.policy.service.pao.model;
 
 import bio.terra.policy.common.model.PolicyInputs;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 
 public class Pao {
   private final UUID objectId;
   private final PaoComponent component;
   private final PaoObjectType objectType;
-  private final PolicyInputs attributes;
-  private final PolicyInputs effectiveAttributes;
-  private final boolean inConflict;
-  private final List<UUID> childObjectIds;
+  private PolicyInputs attributes;
+  private PolicyInputs effectiveAttributes;
+  private Set<UUID> sourceObjectIds;
+  private UUID predecessorId;
 
   public Pao(
       UUID objectId,
@@ -20,15 +20,15 @@ public class Pao {
       PaoObjectType objectType,
       PolicyInputs attributes,
       PolicyInputs effectiveAttributes,
-      boolean inConflict,
-      List<UUID> childObjectIds) {
+      Set<UUID> sourceObjectIds,
+      UUID predecessorId) {
     this.objectId = objectId;
     this.component = component;
     this.objectType = objectType;
     this.attributes = attributes;
     this.effectiveAttributes = effectiveAttributes;
-    this.inConflict = inConflict;
-    this.childObjectIds = childObjectIds;
+    this.sourceObjectIds = sourceObjectIds;
+    this.predecessorId = predecessorId;
   }
 
   public UUID getObjectId() {
@@ -47,16 +47,44 @@ public class Pao {
     return attributes;
   }
 
+  public void setAttributes(PolicyInputs attributes) {
+    this.attributes = attributes;
+  }
+
   public PolicyInputs getEffectiveAttributes() {
     return effectiveAttributes;
   }
 
-  public boolean isInConflict() {
-    return inConflict;
+  public void setEffectiveAttributes(PolicyInputs effectiveAttributes) {
+    this.effectiveAttributes = effectiveAttributes;
   }
 
-  public List<UUID> getChildObjectIds() {
-    return childObjectIds;
+  public Set<UUID> getSourceObjectIds() {
+    return sourceObjectIds;
+  }
+
+  public void setSourceObjectIds(Set<UUID> sourceObjectIds) {
+    this.sourceObjectIds = sourceObjectIds;
+  }
+
+  public UUID getPredecessorId() {
+    return predecessorId;
+  }
+
+  public void setPredecessorId(UUID predecessorId) {
+    this.predecessorId = predecessorId;
+  }
+
+  public Pao duplicateWithoutConflicts() {
+    return new Builder()
+        .setObjectId(objectId)
+        .setComponent(component)
+        .setObjectType(objectType)
+        .setAttributes(attributes.duplicateWithoutConflicts()) // there are never conflicts in here
+        .setEffectiveAttributes(effectiveAttributes.duplicateWithoutConflicts())
+        .setSourceObjectIds(new HashSet<>(sourceObjectIds))
+        .setPredecessorId(predecessorId)
+        .build();
   }
 
   public static class Builder {
@@ -65,8 +93,8 @@ public class Pao {
     private PaoObjectType objectType;
     private PolicyInputs attributes;
     private PolicyInputs effectiveAttributes;
-    private boolean inConflict;
-    private List<UUID> childObjectIds;
+    private Set<UUID> sourceObjectIds;
+    private UUID predecessorId;
 
     public Builder setObjectId(UUID objectId) {
       this.objectId = objectId;
@@ -93,19 +121,19 @@ public class Pao {
       return this;
     }
 
-    public Builder setInConflict(boolean inConflict) {
-      this.inConflict = inConflict;
+    public Builder setSourceObjectIds(Set<UUID> sourceObjectIds) {
+      this.sourceObjectIds = sourceObjectIds;
       return this;
     }
 
-    public Builder setChildObjectIds(List<UUID> childObjectIds) {
-      this.childObjectIds = childObjectIds;
+    public Builder setPredecessorId(UUID predecessorId) {
+      this.predecessorId = predecessorId;
       return this;
     }
 
     public Pao build() {
-      if (childObjectIds == null) {
-        childObjectIds = new ArrayList<>();
+      if (sourceObjectIds == null) {
+        sourceObjectIds = new HashSet<>();
       }
       return new Pao(
           objectId,
@@ -113,8 +141,8 @@ public class Pao {
           objectType,
           attributes,
           effectiveAttributes,
-          inConflict,
-          childObjectIds);
+          sourceObjectIds,
+          predecessorId);
     }
   }
 }

--- a/service/src/main/java/bio/terra/policy/service/pao/model/PaoUpdateMode.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/model/PaoUpdateMode.java
@@ -1,0 +1,7 @@
+package bio.terra.policy.service.pao.model;
+
+public enum PaoUpdateMode {
+  ENFORCE_CONFLICTS,
+  FAIL_ON_CONFLICT,
+  DRY_RUN;
+}

--- a/service/src/main/java/bio/terra/policy/service/policy/PolicyBase.java
+++ b/service/src/main/java/bio/terra/policy/service/policy/PolicyBase.java
@@ -1,0 +1,10 @@
+package bio.terra.policy.service.policy;
+
+import bio.terra.policy.common.model.PolicyInput;
+import bio.terra.policy.common.model.PolicyName;
+
+public interface PolicyBase {
+  PolicyName getPolicyName();
+
+  PolicyInput combine(PolicyInput dependent, PolicyInput source);
+}

--- a/service/src/main/java/bio/terra/policy/service/policy/PolicyCombiner.java
+++ b/service/src/main/java/bio/terra/policy/service/policy/PolicyCombiner.java
@@ -4,6 +4,7 @@ import bio.terra.policy.common.exception.InternalTpsErrorException;
 import bio.terra.policy.common.exception.PolicyNotImplementedException;
 import bio.terra.policy.common.model.PolicyInput;
 import bio.terra.policy.common.model.PolicyName;
+import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 
 public enum PolicyCombiner {
@@ -24,19 +25,19 @@ public enum PolicyCombiner {
     if (!StringUtils.equals(dependent.getKey(), source.getKey())) {
       throw new InternalTpsErrorException("Dependent and source have different policy keys");
     }
-    PolicyBase policy = findPolicyBaseByName(dependent.getPolicyName());
-    if (policy == null) {
+    Optional<PolicyBase> optionalPolicy = findPolicyBaseByName(dependent.getPolicyName());
+    if (optionalPolicy.isEmpty()) {
       throw new PolicyNotImplementedException("Combining unknown policies is not yet implemented");
     }
-    return policy.combine(dependent, source);
+    return optionalPolicy.get().combine(dependent, source);
   }
 
-  public static PolicyBase findPolicyBaseByName(PolicyName name) {
+  public static Optional<PolicyBase> findPolicyBaseByName(PolicyName name) {
     for (PolicyCombiner policyCombiner : values()) {
       if (policyCombiner.getPolicy().getPolicyName().equals(name)) {
-        return policyCombiner.getPolicy();
+        return Optional.of(policyCombiner.getPolicy());
       }
     }
-    return null;
+    return Optional.empty();
   }
 }

--- a/service/src/main/java/bio/terra/policy/service/policy/PolicyCombiner.java
+++ b/service/src/main/java/bio/terra/policy/service/policy/PolicyCombiner.java
@@ -1,0 +1,42 @@
+package bio.terra.policy.service.policy;
+
+import bio.terra.policy.common.exception.InternalTpsErrorException;
+import bio.terra.policy.common.exception.PolicyNotImplementedException;
+import bio.terra.policy.common.model.PolicyInput;
+import bio.terra.policy.common.model.PolicyName;
+import org.apache.commons.lang3.StringUtils;
+
+public enum PolicyCombiner {
+  GROUP_CONSTRAINT(new PolicyGroupConstraint());
+
+  private final PolicyBase policy;
+
+  PolicyCombiner(PolicyBase policy) {
+    this.policy = policy;
+  }
+
+  public PolicyBase getPolicy() {
+    return policy;
+  }
+
+  public static PolicyInput combine(PolicyInput dependent, PolicyInput source) {
+    // Ensure that the inputs are combine-able; this shouldn't happen, but... belts and suspenders.
+    if (!StringUtils.equals(dependent.getKey(), source.getKey())) {
+      throw new InternalTpsErrorException("Dependent and source have different policy keys");
+    }
+    PolicyBase policy = findPolicyBaseByName(dependent.getPolicyName());
+    if (policy == null) {
+      throw new PolicyNotImplementedException("Combining unknown policies is not yet implemented");
+    }
+    return policy.combine(dependent, source);
+  }
+
+  public static PolicyBase findPolicyBaseByName(PolicyName name) {
+    for (PolicyCombiner policyCombiner : values()) {
+      if (policyCombiner.getPolicy().getPolicyName().equals(name)) {
+        return policyCombiner.getPolicy();
+      }
+    }
+    return null;
+  }
+}

--- a/service/src/main/java/bio/terra/policy/service/policy/PolicyGroupConstraint.java
+++ b/service/src/main/java/bio/terra/policy/service/policy/PolicyGroupConstraint.java
@@ -1,0 +1,44 @@
+package bio.terra.policy.service.policy;
+
+import bio.terra.policy.common.model.PolicyInput;
+import bio.terra.policy.common.model.PolicyName;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+public class PolicyGroupConstraint implements PolicyBase {
+  private static final PolicyName POLICY_NAME = new PolicyName("terra", "group-constraint");
+  private static final String DATA_KEY = "group";
+
+  @Override
+  public PolicyName getPolicyName() {
+    return POLICY_NAME;
+  }
+
+  /**
+   * Combine of groups - there is no conflict case. We simply create two Sets of group names from
+   * the comma-separated form, then mash them together, and make them back into comma-separated
+   * form.
+   *
+   * @param dependent policy input
+   * @param source policy input
+   * @return policy input
+   */
+  @Override
+  public PolicyInput combine(PolicyInput dependent, PolicyInput source) {
+    Set<String> dependentSet = dataToSet(dependent.getData(DATA_KEY));
+    Set<String> sourceSet = dataToSet(source.getData(DATA_KEY));
+    dependentSet.addAll(sourceSet);
+    Multimap<String, String> newData = ArrayListMultimap.create();
+    dependentSet.forEach(group -> newData.put(DATA_KEY, group));
+    return new PolicyInput(dependent.getPolicyName(), newData);
+  }
+
+  @VisibleForTesting
+  Set<String> dataToSet(Collection<String> groups) {
+    return new HashSet<>(groups);
+  }
+}

--- a/service/src/main/java/bio/terra/policy/service/policy/model/ChangeDescription.java
+++ b/service/src/main/java/bio/terra/policy/service/policy/model/ChangeDescription.java
@@ -1,0 +1,8 @@
+package bio.terra.policy.service.policy.model;
+
+import bio.terra.policy.common.model.PolicyInputs;
+import bio.terra.policy.service.pao.graph.model.PolicyConflict;
+import java.util.List;
+
+public record ChangeDescription(
+    PolicyInputs newEffectiveAttributes, List<PolicyConflict> conflicts) {}

--- a/service/src/main/java/bio/terra/policy/service/policy/model/ChangeDescription.java
+++ b/service/src/main/java/bio/terra/policy/service/policy/model/ChangeDescription.java
@@ -1,8 +1,0 @@
-package bio.terra.policy.service.policy.model;
-
-import bio.terra.policy.common.model.PolicyInputs;
-import bio.terra.policy.service.pao.graph.model.PolicyConflict;
-import java.util.List;
-
-public record ChangeDescription(
-    PolicyInputs newEffectiveAttributes, List<PolicyConflict> conflicts) {}

--- a/service/src/main/java/bio/terra/policy/service/policy/model/LinkSourceResult.java
+++ b/service/src/main/java/bio/terra/policy/service/policy/model/LinkSourceResult.java
@@ -1,0 +1,7 @@
+package bio.terra.policy.service.policy.model;
+
+import bio.terra.policy.service.pao.graph.model.PolicyConflict;
+import bio.terra.policy.service.pao.model.Pao;
+import java.util.List;
+
+public record LinkSourceResult(Pao computedPao, List<PolicyConflict> conflicts) {}

--- a/service/src/main/resources/policydb/changelog.xml
+++ b/service/src/main/resources/policydb/changelog.xml
@@ -5,4 +5,5 @@
 
   <include file="changesets/20220608_initial.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20220811_attribute_set_index.yaml" relativeToChangelogFile="true"/>
+  <include file="changesets/20220812_pao_features.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/service/src/main/resources/policydb/changesets/20220812_pao_features.yaml
+++ b/service/src/main/resources/policydb/changesets/20220812_pao_features.yaml
@@ -1,0 +1,27 @@
+databaseChangeLog:
+  - changeSet:
+      id: pao_features
+      author: dd
+      changes:
+      - addColumn:
+          tableName: policy_object
+          columns:
+            - column:
+                name: predecessor_id
+                type: text
+                remarks: UUID of the predecessor PAO
+      - dropColumn:
+          tableName: policy_object
+          columnName: in_conflict
+      - renameColumn:
+          tableName: policy_object
+          oldColumnName: children
+          newColumnName: sources
+          remarks: Array of ids of paos that this pao depends on
+      - addColumn:
+          tableName: attribute_set
+          columns:
+            - column:
+                name: conflicts
+                type: text[]
+                remarks: Array of conflicting PAOs. There should always be an array, even if it is empty.


### PR DESCRIPTION
This PR is an omnibus of changes driven by working through how propagating changes and conflicts would work. I'm putting this code in now so Mike can work on his TPS tickets in parallel with my getting the update path tested and debugged.

Some notable changes:

### Database schema
- Added a predecessor pointer to support clone 
- Renamed `children` to `sources`
- Removed the `in_conflict` boolean from the PAO
- Added a list of conflicting object ids to the policy attribute

### Additional Data
- changed additional data from being a Map to a Multimap, so we have a better way of supporting things like group-constraint
- added DbAdditionalData to put Multimap into a serializable format for database storage, and back again

### Graph walking
- Added non-transactional methods to support graph walk and update as one big transactions.
- Added graph model and walker. This is untested. It needs extensive testing. 

### Beginnings of Policy Processing
- Made a policy base class (PolicyBase) and an enumeration that can dispatch to specific implementations (PolicyCombiner)
- Made an instance for group constraint (PolicyGroupDescription)

### Loose ends:
- tests for graph walking
- WSM updates to rename `children`, remove `in_conflict`, and add `conflicts` to match the revised data model. I think we do not want to take this version of the code into WSM until those changes are made.