### PR TITLE
[PF-1927] revamp attribute evaluation and add tests

### DIFF
--- a/service/src/main/java/bio/terra/policy/common/model/PolicyInput.java
+++ b/service/src/main/java/bio/terra/policy/common/model/PolicyInput.java
@@ -62,8 +62,11 @@ public class PolicyInput {
     return conflicts;
   }
 
-  public PolicyInput duplicateWithoutConflicts() {
-    return new PolicyInput(policyName, additionalData);
+  public PolicyInput duplicate() {
+    PolicyName dupPolicyName = new PolicyName(policyName.getNamespace(), policyName.getName());
+    Multimap<String, String> dupAdditionalData = ArrayListMultimap.create(additionalData);
+    Set<UUID> dupConflicts = new HashSet<>(conflicts);
+    return new PolicyInput(dupPolicyName, dupAdditionalData, dupConflicts);
   }
 
   @Override

--- a/service/src/main/java/bio/terra/policy/common/model/PolicyInputs.java
+++ b/service/src/main/java/bio/terra/policy/common/model/PolicyInputs.java
@@ -51,15 +51,6 @@ public class PolicyInputs {
     return inputs;
   }
 
-  public PolicyInputs duplicateWithoutConflicts() {
-    Map<String, PolicyInput> dupMap = new HashMap<>();
-    for (var entry : inputs.entrySet()) {
-      var dupInput = entry.getValue().duplicateWithoutConflicts();
-      dupMap.put(entry.getKey(), dupInput);
-    }
-    return new PolicyInputs(dupMap);
-  }
-
   @Override
   public String toString() {
     return new StringJoiner(", ", PolicyInputs.class.getSimpleName() + "[", "]")

--- a/service/src/main/java/bio/terra/policy/service/pao/graph/Walker.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/graph/Walker.java
@@ -78,7 +78,7 @@ public class Walker {
     makeSourcesList(inputNode);
 
     // Construct the evaluation structure for computing the effective of this node
-    AttributeEvaluator evaluator = new AttributeEvaluator();
+    AttributeEvaluator evaluator = new AttributeEvaluator(inputNode.getPao());
     evaluator.addAttributeSet(inputNode.getObjectAttributeSet());
     for (GraphNode source : inputNode.getSources()) {
       evaluator.addAttributeSet(source.getEffectiveAttributeSet());
@@ -95,7 +95,7 @@ public class Walker {
 
     // There was a change. Save the change as the new effective attributes
     // and mark the node modified so we know to write it back to the database later.
-    // Save the conflicts to the object list
+    // Save the conflicts to the walker list of all new conflicts
     inputNode.setEffectiveAttributeSet(newEffectiveAttributes);
     inputNode.setModified(true);
     newConflicts.addAll(conflicts);

--- a/service/src/main/java/bio/terra/policy/service/pao/graph/Walker.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/graph/Walker.java
@@ -1,8 +1,13 @@
 package bio.terra.policy.service.pao.graph;
 
+import bio.terra.policy.common.exception.InternalTpsErrorException;
 import bio.terra.policy.common.model.PolicyInput;
 import bio.terra.policy.common.model.PolicyInputs;
 import bio.terra.policy.db.PaoDao;
+import bio.terra.policy.service.pao.graph.model.AttributeEvaluator;
+import bio.terra.policy.service.pao.graph.model.GraphAttribute;
+import bio.terra.policy.service.pao.graph.model.GraphAttributeConflict;
+import bio.terra.policy.service.pao.graph.model.GraphAttributeSet;
 import bio.terra.policy.service.pao.graph.model.GraphNode;
 import bio.terra.policy.service.pao.graph.model.PolicyConflict;
 import bio.terra.policy.service.pao.model.Pao;
@@ -21,20 +26,31 @@ import java.util.UUID;
 public class Walker {
   private final PaoDao paoDao;
   private final Map<UUID, GraphNode> paoMap;
-  private final GraphNode targetNode;
-
-  public Walker(PaoDao paoDao, Pao initialPao, Pao modifiedPao) {
+  private final List<PolicyConflict> newConflicts;
+  /**
+   * Constructing the Walker object performs the graph walk. That computes new effective
+   * policies for the objects. The modifiedPao
+   *
+   * @param paoDao reference to the DAO so we can read and possibly update policies
+   * @param pao with proposed modification
+   * @param changedPaoId object id of the change. If this is a change to the policy of an
+   *                     object, the id will be the same as the pao. If this is adding
+   *                     a new source to the object, this will be the id of the new source Pao.
+   * TODO: is this the best way to express the change?
+   */
+  public Walker(PaoDao paoDao, Pao pao, UUID changedPaoId) {
     this.paoDao = paoDao;
     this.paoMap = new HashMap<>();
-    this.targetNode =
-        new GraphNode()
-            .setInitialPao(initialPao)
-            .setComputePao(modifiedPao)
-            .setModified(true)
-            .setNewConflict(false);
-    paoMap.put(modifiedPao.getObjectId(), targetNode);
+    this.newConflicts = new ArrayList<>();
+
+    GraphNode targetNode = new GraphNode(pao, true);
+    paoMap.put(pao.getObjectId(), targetNode);
+    walkNode(targetNode, changedPaoId);
   }
 
+  /**
+   * Apply the changes computed by the walker
+   */
   public void applyChanges() {
     List<GraphNode> changeList = new ArrayList<>();
     for (GraphNode node : paoMap.values()) {
@@ -48,78 +64,51 @@ public class Walker {
   }
 
   /**
-   * Recursively walk the policy graph building a map of modified Paos and a list of the conflicts
-   * caused by the modified policy.
-   *
+   * Getter for returning conflicts from the walk
    * @return list of policy conflicts
    */
-  public List<PolicyConflict> walk() {
-    walkNode(targetNode);
-    return computeConflict();
+  public List<PolicyConflict> getNewConflicts() {
+    return newConflicts;
   }
 
-  private void walkNode(GraphNode inputNode) {
-    // We re-compute the effective attribute set from our set attributes and our sources
+  /**
+   * Recursive graph walker
+   * @param inputNode graph node we are processing
+   * @param changedPaoId the object id of the Pao that changed
+   */
+  private void walkNode(GraphNode inputNode, UUID changedPaoId) {
+    // Build graph nodes for all of the sources
     makeSourcesList(inputNode);
-    Pao inputPao = inputNode.getComputePao();
-    PolicyInputs runningEffectiveSet = inputPao.getAttributes();
-    for (GraphNode source : inputNode.getSources()) {
-      runningEffectiveSet = computeEffective(runningEffectiveSet, source);
-    }
 
-    // If there is no change to the input effective attribute set, then we stop recursing.
-    // We will not cause a change in any of our dependents. We still might have a conflict.
-    if (runningEffectiveSet.equals(inputPao.getEffectiveAttributes())) {
+    // Construct the evaluation structure for computing the effective
+    AttributeEvaluator evaluator = new AttributeEvaluator();
+    evaluator.addAttributeSet(inputNode.getEffectiveAttributeSet());
+    for (GraphNode source : inputNode.getSources()) {
+      evaluator.addAttributeSet(source.getEffectiveAttributeSet());
+    }
+    GraphAttributeSet newEffectiveAttributes = evaluator.evaluate(changedPaoId);
+    List<PolicyConflict> conflicts = gatherNewConflicts(newEffectiveAttributes);
+
+    // If there is no change to the input effective attribute set and there are no new
+    // conflicts, then we stop recursing. We won't cause a change to our dependents.
+    if (newEffectiveAttributes.equals(inputNode.getEffectiveAttributeSet()) && conflicts.isEmpty()) {
       return;
     }
 
-    // There was a change, so we have more work to do.
-    // Save the changes and mark us as changed.
-    inputPao.setEffectiveAttributes(runningEffectiveSet);
+    // There was a change. Save the change as the new effective attributes
+    // and mark the node modified so we know to write it back to the database later.
+    // Save the conflicts to the object list
+    inputNode.setEffectiveAttributeSet(newEffectiveAttributes);
     inputNode.setModified(true);
+    newConflicts.addAll(conflicts);
 
     // Recursively walk our dependents. We know that these dependents will
     // refer to this changed node in recalculating their effective attribute set.
+    // When we recurse, this Pao is the one that changed
     makeDependentsList(inputNode);
     for (GraphNode dependent : inputNode.getDependents()) {
-      walkNode(dependent);
+      walkNode(dependent, inputNode.getPao().getObjectId());
     }
-  }
-
-  private PolicyInputs computeEffective(PolicyInputs dependentInputs, GraphNode sourceNode) {
-    PolicyInputs newDependentEffective = new PolicyInputs();
-    PolicyInputs sourceInputs = sourceNode.getComputePao().getEffectiveAttributes();
-
-    // First traverse the input and probe the source. We take care of all combining
-    // in this pass.
-    for (PolicyInput dependentInput : dependentInputs.getInputs().values()) {
-      PolicyInput sourceInput = sourceInputs.lookupPolicy(dependentInput);
-      if (sourceInput == null) {
-        newDependentEffective.addInput(dependentInput);
-      } else {
-        PolicyInput resultInput = PolicyMutator.combine(dependentInput, sourceInput);
-        if (resultInput == null) {
-          // Combiner failed, so we have a conflict. Record the conflict in the input's
-          // conflict set. Use the existing dependent input as the effective policy; that is,
-          // when there is a conflict, we retain the existing policy setting and remember
-          // the conflict.
-          dependentInput.getConflicts().add(sourceNode.getComputePao().getObjectId());
-          newDependentEffective.addInput(dependentInput);
-        } else {
-          newDependentEffective.addInput(resultInput);
-        }
-      }
-    }
-
-    // Second traverse the source and probe the dependents. Add any non-matches and ignore the rest
-    for (PolicyInput input : sourceInputs.getInputs().values()) {
-      PolicyInput dependentInput = dependentInputs.lookupPolicy(input);
-      if (dependentInput == null) {
-        newDependentEffective.addInput(input);
-      }
-    }
-
-    return newDependentEffective;
   }
 
   private void makeSourcesList(GraphNode node) {
@@ -127,7 +116,7 @@ public class Walker {
     if (node.getSources() != null) {
       return;
     }
-    List<GraphNode> sources = makeGraphList(node.getComputePao().getSourceObjectIds());
+    List<GraphNode> sources = makeGraphList(node.getPao().getSourceObjectIds());
     node.setSources(sources);
   }
 
@@ -136,7 +125,7 @@ public class Walker {
     if (node.getDependents() != null) {
       return;
     }
-    Set<UUID> dependentIds = paoDao.getDependentIds(node.getComputePao().getObjectId());
+    Set<UUID> dependentIds = paoDao.getDependentIds(node.getPao().getObjectId());
     List<GraphNode> dependents = makeGraphList(dependentIds);
     node.setDependents(dependents);
   }
@@ -156,67 +145,35 @@ public class Walker {
     }
 
     // Fetch the Paos that were not in the map; make graph nodes and add them to the map.
-    // New nodes always start without conflicts and unmodified.
+    // New nodes always start without new conflicts and unmodified.
     List<Pao> daoFetchResult = paoDao.getPaos(daoFetchIds);
     for (Pao pao : daoFetchResult) {
-      var node =
-          new GraphNode()
-              .setInitialPao(pao)
-              .setComputePao(pao.duplicateWithoutConflicts())
-              .setModified(false)
-              .setNewConflict(false);
+      var node = new GraphNode(pao, false);
       graphList.add(node);
       paoMap.put(pao.getObjectId(), node);
     }
     return graphList;
   }
 
-  /**
-   * Make a pass through the graph checking to see if the evaluation of the change caused any new
-   * conflicts. Return the list of conflicts, if any.
-   *
-   * @return conflictList
-   */
-  private List<PolicyConflict> computeConflict() {
-    List<PolicyConflict> conflictList = new ArrayList<>();
-    for (GraphNode node : paoMap.values()) {
-      if (computeNodeConflict(node, conflictList)) {
-        node.setNewConflict(true);
+  private List<PolicyConflict> gatherNewConflicts(GraphAttributeSet attributeSet) {
+    List<PolicyConflict> conflicts = new ArrayList<>();
+    for (GraphAttribute graphAttribute : attributeSet.getAttributes()) {
+      Pao containingPao = getPaoFromGraphNode(graphAttribute.getContainingPaoId());
+
+      // Build a conflict result for each new conflict
+      for (UUID conflictId : graphAttribute.getNewConflicts()) {
+        Pao conflictPao = getPaoFromGraphNode(conflictId);
+        conflicts.add(new PolicyConflict(containingPao, conflictPao, graphAttribute.getPolicyInput().getPolicyName()));
       }
     }
-    return conflictList;
+    return conflicts;
   }
 
-  private boolean computeNodeConflict(GraphNode node, List<PolicyConflict> conflicts) {
-    // If the node is not modified, there is nothing to do
-    if (!node.isModified()) {
-      return false;
+  private Pao getPaoFromGraphNode(UUID objectId) {
+    GraphNode node = paoMap.get(objectId);
+    if (node == null) {
+      throw new InternalTpsErrorException("Unexpected null graph node!");
     }
-
-    boolean foundNewConflicts = false;
-    PolicyInputs initialInputs = node.getInitialPao().getEffectiveAttributes();
-    PolicyInputs modifiedInputs = node.getComputePao().getEffectiveAttributes();
-
-    for (var entry : modifiedInputs.getInputs().entrySet()) {
-      PolicyInput initialInput = initialInputs.getInputs().get(entry.getKey());
-      // If there is no existing matching policy, there can be no conflict
-      if (initialInput == null) {
-        continue;
-      }
-      Set<UUID> initialConflicts = initialInput.getConflicts();
-      Set<UUID> newConflicts = entry.getValue().getConflicts();
-      for (var conflictId : newConflicts) {
-        // If the conflict is new - not in the initial state - then we mark the node
-        if (!initialConflicts.contains(conflictId)) {
-          conflicts.add(
-              new PolicyConflict(
-                  node.getComputePao(),
-                  paoMap.get(conflictId).getComputePao(),
-                  initialInput.getPolicyName()));
-          foundNewConflicts = true;
-        }
-      }
-    }
-    return foundNewConflicts;
+    return node.getPao();
   }
 }

--- a/service/src/main/java/bio/terra/policy/service/pao/graph/Walker.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/graph/Walker.java
@@ -25,7 +25,7 @@ public class Walker {
   private final List<PolicyConflict> newConflicts;
   /**
    * Constructing the Walker object performs the graph walk. That computes new effective policies
-   * for the objects. The modifiedPao
+   * for the objects.
    *
    * @param paoDao reference to the DAO so we can read and possibly update policies
    * @param pao with proposed modification
@@ -59,9 +59,9 @@ public class Walker {
   }
 
   /**
-   * Getter for returning conflicts from the walk
+   * Getter for returning new conflicts from the walk
    *
-   * @return list of policy conflicts
+   * @return list of any new policy conflicts
    */
   public List<PolicyConflict> getNewConflicts() {
     return newConflicts;

--- a/service/src/main/java/bio/terra/policy/service/pao/graph/Walker.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/graph/Walker.java
@@ -41,6 +41,8 @@ public class Walker {
     GraphNode targetNode = new GraphNode(pao, true);
     paoMap.put(pao.getObjectId(), targetNode);
     walkNode(targetNode, changedPaoId);
+    // Fill in the resulting effective attributes, so they can be returned in the update response
+    targetNode.getPao().setEffectiveAttributes(targetNode.getEffectivePolicyAttributes());
   }
 
   /** Apply the changes computed by the walker */
@@ -75,9 +77,9 @@ public class Walker {
     // Build graph nodes for all of the sources
     makeSourcesList(inputNode);
 
-    // Construct the evaluation structure for computing the effective
+    // Construct the evaluation structure for computing the effective of this node
     AttributeEvaluator evaluator = new AttributeEvaluator();
-    evaluator.addAttributeSet(inputNode.getEffectiveAttributeSet());
+    evaluator.addAttributeSet(inputNode.getObjectAttributeSet());
     for (GraphNode source : inputNode.getSources()) {
       evaluator.addAttributeSet(source.getEffectiveAttributeSet());
     }

--- a/service/src/main/java/bio/terra/policy/service/pao/graph/model/AttributeEvaluator.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/graph/model/AttributeEvaluator.java
@@ -2,120 +2,123 @@ package bio.terra.policy.service.pao.graph.model;
 
 import bio.terra.policy.common.model.PolicyInput;
 import bio.terra.policy.service.policy.PolicyMutator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * This code does the processing that turns a group of policy attributes from PAOs into
- * a single, effective attribute set. The expected usage is:
- * 1. construct the evaluator
- * 2. add the attributes sets that are to be processed
- * 3. call evaluate() to perform the evaluation.
+ * This code does the processing that turns a group of policy attributes from PAOs into a single,
+ * effective attribute set. The expected usage is: 1. construct the evaluator 2. add the attributes
+ * sets that are to be processed 3. call evaluate() to perform the evaluation.
  */
 public class AttributeEvaluator {
-    private static final Logger logger = LoggerFactory.getLogger(AttributeEvaluator.class);
-    private final Map<String, List<GraphAttribute>> inputs;
+  private static final Logger logger = LoggerFactory.getLogger(AttributeEvaluator.class);
+  private final Map<String, List<GraphAttribute>> inputs;
 
-    public AttributeEvaluator() {
-        this.inputs = new HashMap<>();
-    }
-
-    public void addAttributeSet(GraphAttributeSet attributeSet) {
-        for (GraphAttribute attribute : attributeSet.getAttributes()) {
-            addAttribute(attribute.getPolicyInput().getKey(), attribute);
-        }
-    }
-
-    public GraphAttributeSet evaluate(UUID changedPaoId) {
-        // Start with an empty attribute set
-        var effectiveAttributeSet = new GraphAttributeSet();
-        inputs.forEach((k, v) -> effectiveAttributeSet.putAttribute(evaluateOnePolicy(k, v, changedPaoId)));
-        return effectiveAttributeSet;
-    }
-
-  private GraphAttribute evaluateOnePolicy(String key, List<GraphAttribute> attributeList, UUID changedPaoId) {
-      // Three settings that control the order we combine policies on our list:
-      //  - is it changed (does the changedPaoId != the containingPao id)
-      //  - does it have existing conflicts
-      //  - does it have new conflicts
-      //
-      // We processd in order:
-      // 1. unchanged, no existing conflicts, no new conflicts
-      // 2. unchanged, existing conflicts, no new conflicts
-      // 3. unchanged, new conflicts (both existing cases are done)
-      // 4. changed items
-      //
-      // We remove items from the list as they are combined in, so we don't have to filter
-      // them out.
-
-      GraphAttribute newAttribute = null;
-
-      // Combo 1: unchanged, no existing conflicts, no new conflicts
-      List<GraphAttribute> remainingList1 = new ArrayList<>();
-      for (GraphAttribute attribute : attributeList) {
-          if (attribute.isChanged(changedPaoId) ||
-              attribute.hasNewConflict() ||
-              attribute.hasExistingConflict()) {
-              remainingList1.add(attribute);
-          } else {
-              newAttribute = combineAttribute(newAttribute, attribute);
-          }
-      }
-
-      // Combo 2: unchanged, existing conflicts, no new conflicts
-      List<GraphAttribute> remainingList2 = new ArrayList<>();
-      for (GraphAttribute attribute : remainingList1) {
-          if (attribute.isChanged(changedPaoId) ||
-              attribute.hasNewConflict()) {
-              remainingList2.add(attribute);
-          } else {
-              newAttribute = combineAttribute(newAttribute, attribute);
-          }
-      }
-
-      // Combo 3: unchanged, new conflicts
-      List<GraphAttribute> remainingList3 = new ArrayList<>();
-      for (GraphAttribute attribute : remainingList2) {
-          if (attribute.isChanged(changedPaoId) ||
-              attribute.hasNewConflict()) {
-              remainingList3.add(attribute);
-          } else {
-              newAttribute = combineAttribute(newAttribute, attribute);
-          }
-      }
-
-      for (GraphAttribute attribute : remainingList3) {
-          newAttribute = combineAttribute(newAttribute, attribute);
-      }
-
-      return newAttribute;
+  public AttributeEvaluator() {
+    this.inputs = new HashMap<>();
   }
 
-    private GraphAttribute combineAttribute(GraphAttribute newAttribute, GraphAttribute attribute) {
-        PolicyInput input = attribute.getPolicyInput();
-        if (newAttribute == null) {
-            return new GraphAttribute(attribute.getContainingPaoId(), input);
-        }
+  public void addAttributeSet(GraphAttributeSet attributeSet) {
+    for (GraphAttribute attribute : attributeSet.getAttributes()) {
+      addAttribute(attribute.getPolicyInput().getKey(), attribute);
+    }
+  }
 
-        PolicyInput currentInput = newAttribute.getPolicyInput();
-        PolicyInput resultInput = PolicyMutator.combine(currentInput, input);
-        // We propagate conflicts through dependents even if the policies are fine otherwise.
-        if (resultInput == null || attribute.hasNewConflict()) {
-            newAttribute.setNewConflict(attribute.getContainingPaoId());
-        } else {
-            newAttribute.setPolicyInput(resultInput);
-        }
-        return newAttribute;
+  public GraphAttributeSet evaluate(UUID changedPaoId) {
+    // Start with an empty attribute set
+    var effectiveAttributeSet = new GraphAttributeSet();
+    inputs.forEach(
+        (k, v) -> effectiveAttributeSet.putAttribute(evaluateOnePolicy(k, v, changedPaoId)));
+    return effectiveAttributeSet;
+  }
+
+  private GraphAttribute evaluateOnePolicy(
+      String key, List<GraphAttribute> attributeList, UUID changedPaoId) {
+    // Three settings that control the order we combine policies on our list:
+    //  - is it changed (does the changedPaoId != the containingPao id)
+    //  - does it have existing conflicts
+    //  - does it have new conflicts
+    //
+    // We processd in order:
+    // 1. unchanged, no existing conflicts, no new conflicts
+    // 2. unchanged, existing conflicts, no new conflicts
+    // 3. unchanged, new conflicts (both existing cases are done)
+    // 4. changed items
+    //
+    // We remove items from the list as they are combined in, so we don't have to filter
+    // them out.
+
+    GraphAttribute newAttribute = null;
+
+    // Combo 1: unchanged, no existing conflicts, no new conflicts
+    List<GraphAttribute> remainingList1 = new ArrayList<>();
+    for (GraphAttribute attribute : attributeList) {
+      if (attribute.isChanged(changedPaoId)
+          || attribute.hasNewConflict()
+          || attribute.hasExistingConflict()) {
+        remainingList1.add(attribute);
+      } else {
+        newAttribute = combineAttribute(newAttribute, attribute);
+      }
     }
 
-    private void addAttribute(String key, GraphAttribute graphAttribute) {
-        List<GraphAttribute> graphAttributeList = inputs.computeIfAbsent(key, k -> new ArrayList<>());
-        graphAttributeList.add(graphAttribute);
+    // Combo 2: unchanged, existing conflicts, no new conflicts
+    List<GraphAttribute> remainingList2 = new ArrayList<>();
+    for (GraphAttribute attribute : remainingList1) {
+      if (attribute.isChanged(changedPaoId) || attribute.hasNewConflict()) {
+        remainingList2.add(attribute);
+      } else {
+        newAttribute = combineAttribute(newAttribute, attribute);
+      }
     }
+
+    // Combo 3: unchanged, new conflicts
+    List<GraphAttribute> remainingList3 = new ArrayList<>();
+    for (GraphAttribute attribute : remainingList2) {
+      if (attribute.isChanged(changedPaoId) || attribute.hasNewConflict()) {
+        remainingList3.add(attribute);
+      } else {
+        newAttribute = combineAttribute(newAttribute, attribute);
+      }
+    }
+
+    for (GraphAttribute attribute : remainingList3) {
+      newAttribute = combineAttribute(newAttribute, attribute);
+    }
+
+    return newAttribute;
+  }
+
+  // combine attribute into newAttribute
+  private GraphAttribute combineAttribute(GraphAttribute newAttribute, GraphAttribute attribute) {
+    PolicyInput input = attribute.getPolicyInput();
+    if (newAttribute == null) {
+      return new GraphAttribute(attribute.getContainingPao(), input);
+    }
+
+    PolicyInput currentInput = newAttribute.getPolicyInput();
+    PolicyInput resultInput = PolicyMutator.combine(currentInput, input);
+    // We propagate conflicts through dependents even if the policies are fine otherwise.
+    if (resultInput == null || attribute.hasNewConflict()) {
+      UUID id = attribute.getContainingPao().getObjectId();
+      if (attribute.getPolicyInput().getConflicts().contains(id)) {
+        newAttribute.setExistingConflict(id);
+      } else {
+        newAttribute.setNewConflict(id);
+      }
+    } else {
+      newAttribute.setPolicyInput(resultInput);
+    }
+    return newAttribute;
+  }
+
+  private void addAttribute(String key, GraphAttribute graphAttribute) {
+    List<GraphAttribute> graphAttributeList = inputs.computeIfAbsent(key, k -> new ArrayList<>());
+    graphAttributeList.add(graphAttribute);
+  }
 }

--- a/service/src/main/java/bio/terra/policy/service/pao/graph/model/AttributeEvaluator.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/graph/model/AttributeEvaluator.java
@@ -107,7 +107,7 @@ public class AttributeEvaluator {
     if (resultInput == null || attribute.hasNewConflict()) {
       UUID id = attribute.getContainingPao().getObjectId();
       if (attribute.getPolicyInput().getConflicts().contains(id)) {
-        newAttribute.setExistingConflict(id);
+        newAttribute.setReFoundConflict(id);
       } else {
         newAttribute.setNewConflict(id);
       }

--- a/service/src/main/java/bio/terra/policy/service/pao/graph/model/AttributeEvaluator.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/graph/model/AttributeEvaluator.java
@@ -1,0 +1,121 @@
+package bio.terra.policy.service.pao.graph.model;
+
+import bio.terra.policy.common.model.PolicyInput;
+import bio.terra.policy.service.policy.PolicyMutator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * This code does the processing that turns a group of policy attributes from PAOs into
+ * a single, effective attribute set. The expected usage is:
+ * 1. construct the evaluator
+ * 2. add the attributes sets that are to be processed
+ * 3. call evaluate() to perform the evaluation.
+ */
+public class AttributeEvaluator {
+    private static final Logger logger = LoggerFactory.getLogger(AttributeEvaluator.class);
+    private final Map<String, List<GraphAttribute>> inputs;
+
+    public AttributeEvaluator() {
+        this.inputs = new HashMap<>();
+    }
+
+    public void addAttributeSet(GraphAttributeSet attributeSet) {
+        for (GraphAttribute attribute : attributeSet.getAttributes()) {
+            addAttribute(attribute.getPolicyInput().getKey(), attribute);
+        }
+    }
+
+    public GraphAttributeSet evaluate(UUID changedPaoId) {
+        // Start with an empty attribute set
+        var effectiveAttributeSet = new GraphAttributeSet();
+        inputs.forEach((k, v) -> effectiveAttributeSet.putAttribute(evaluateOnePolicy(k, v, changedPaoId)));
+        return effectiveAttributeSet;
+    }
+
+  private GraphAttribute evaluateOnePolicy(String key, List<GraphAttribute> attributeList, UUID changedPaoId) {
+      // Three settings that control the order we combine policies on our list:
+      //  - is it changed (does the changedPaoId != the containingPao id)
+      //  - does it have existing conflicts
+      //  - does it have new conflicts
+      //
+      // We processd in order:
+      // 1. unchanged, no existing conflicts, no new conflicts
+      // 2. unchanged, existing conflicts, no new conflicts
+      // 3. unchanged, new conflicts (both existing cases are done)
+      // 4. changed items
+      //
+      // We remove items from the list as they are combined in, so we don't have to filter
+      // them out.
+
+      GraphAttribute newAttribute = null;
+
+      // Combo 1: unchanged, no existing conflicts, no new conflicts
+      List<GraphAttribute> remainingList1 = new ArrayList<>();
+      for (GraphAttribute attribute : attributeList) {
+          if (attribute.isChanged(changedPaoId) ||
+              attribute.hasNewConflict() ||
+              attribute.hasExistingConflict()) {
+              remainingList1.add(attribute);
+          } else {
+              newAttribute = combineAttribute(newAttribute, attribute);
+          }
+      }
+
+      // Combo 2: unchanged, existing conflicts, no new conflicts
+      List<GraphAttribute> remainingList2 = new ArrayList<>();
+      for (GraphAttribute attribute : remainingList1) {
+          if (attribute.isChanged(changedPaoId) ||
+              attribute.hasNewConflict()) {
+              remainingList2.add(attribute);
+          } else {
+              newAttribute = combineAttribute(newAttribute, attribute);
+          }
+      }
+
+      // Combo 3: unchanged, new conflicts
+      List<GraphAttribute> remainingList3 = new ArrayList<>();
+      for (GraphAttribute attribute : remainingList2) {
+          if (attribute.isChanged(changedPaoId) ||
+              attribute.hasNewConflict()) {
+              remainingList3.add(attribute);
+          } else {
+              newAttribute = combineAttribute(newAttribute, attribute);
+          }
+      }
+
+      for (GraphAttribute attribute : remainingList3) {
+          newAttribute = combineAttribute(newAttribute, attribute);
+      }
+
+      return newAttribute;
+  }
+
+    private GraphAttribute combineAttribute(GraphAttribute newAttribute, GraphAttribute attribute) {
+        PolicyInput input = attribute.getPolicyInput();
+        if (newAttribute == null) {
+            return new GraphAttribute(attribute.getContainingPaoId(), input);
+        }
+
+        PolicyInput currentInput = newAttribute.getPolicyInput();
+        PolicyInput resultInput = PolicyMutator.combine(currentInput, input);
+        // We propagate conflicts through dependents even if the policies are fine otherwise.
+        if (resultInput == null || attribute.hasNewConflict()) {
+            newAttribute.setNewConflict(attribute.getContainingPaoId());
+        } else {
+            newAttribute.setPolicyInput(resultInput);
+        }
+        return newAttribute;
+    }
+
+    private void addAttribute(String key, GraphAttribute graphAttribute) {
+        List<GraphAttribute> graphAttributeList = inputs.computeIfAbsent(key, k -> new ArrayList<>());
+        graphAttributeList.add(graphAttribute);
+    }
+}

--- a/service/src/main/java/bio/terra/policy/service/pao/graph/model/AttributeEvaluator.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/graph/model/AttributeEvaluator.java
@@ -13,8 +13,13 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This code does the processing that turns a group of policy attributes from PAOs into a single,
- * effective attribute set. The expected usage is: 1. construct the evaluator 2. add the attributes
- * sets that are to be processed 3. call evaluate() to perform the evaluation.
+ * effective attribute set. The expected usage is:
+ *
+ * <ol>
+ *   <li>construct the evaluator
+ *   <li>add the attributes sets that are to be processed
+ *   <li>call evaluate() to perform the evaluation
+ * </ol>
  */
 public class AttributeEvaluator {
   private static final Logger logger = LoggerFactory.getLogger(AttributeEvaluator.class);
@@ -127,9 +132,9 @@ public class AttributeEvaluator {
   private void propagateConflict(GraphAttribute newAttribute, GraphAttribute attribute) {
     UUID id = attribute.getContainingPao().getObjectId();
     if (attribute.getPolicyInput().getConflicts().contains(id)) {
-      newAttribute.setReFoundConflict(id);
+      newAttribute.addReFoundConflict(id);
     } else {
-      newAttribute.setNewConflict(id);
+      newAttribute.addNewConflict(id);
     }
   }
 

--- a/service/src/main/java/bio/terra/policy/service/pao/graph/model/GraphAttribute.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/graph/model/GraphAttribute.java
@@ -14,7 +14,7 @@ public class GraphAttribute {
 
   public GraphAttribute(Pao containingPao, PolicyInput policyInput) {
     this.containingPao = containingPao;
-    this.policyInput = policyInput.duplicateWithoutConflicts();
+    this.policyInput = policyInput.duplicate();
     reFoundConflicts = new HashSet<>();
     newConflicts = new HashSet<>();
   }

--- a/service/src/main/java/bio/terra/policy/service/pao/graph/model/GraphAttribute.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/graph/model/GraphAttribute.java
@@ -9,13 +9,13 @@ import java.util.UUID;
 public class GraphAttribute {
   private PolicyInput policyInput; // the attribute
   private final Pao containingPao; // the PAO it comes from
-  private final Set<UUID> existingConflicts; // re-found conflicts
+  private final Set<UUID> reFoundConflicts; // re-found conflicts
   private final Set<UUID> newConflicts; // new conflicts
 
   public GraphAttribute(Pao containingPao, PolicyInput policyInput) {
     this.containingPao = containingPao;
     this.policyInput = policyInput.duplicateWithoutConflicts();
-    existingConflicts = new HashSet<>();
+    reFoundConflicts = new HashSet<>();
     newConflicts = new HashSet<>();
   }
 
@@ -31,31 +31,35 @@ public class GraphAttribute {
     return containingPao;
   }
 
-  public Set<UUID> getExistingConflicts() {
-    return existingConflicts;
+  public Set<UUID> getReFoundConflicts() {
+    return reFoundConflicts;
   }
 
   public Set<UUID> getNewConflicts() {
     return newConflicts;
   }
 
-  public boolean hasExistingConflict() {
-    return !existingConflicts.isEmpty();
+  public boolean hasReFoundConflict() {
+    return !reFoundConflicts.isEmpty();
   }
 
   public boolean hasNewConflict() {
     return !newConflicts.isEmpty();
   }
 
+  public boolean hasExistingConflict() {
+    return !policyInput.getConflicts().isEmpty();
+  }
+
   public boolean isChanged(UUID changedPaoId) {
-    return (containingPao.equals(changedPaoId));
+    return (containingPao.getObjectId().equals(changedPaoId));
   }
 
   public void setNewConflict(UUID conflict) {
     newConflicts.add(conflict);
   }
 
-  public void setExistingConflict(UUID conflict) {
-    existingConflicts.add(conflict);
+  public void setReFoundConflict(UUID conflict) {
+    reFoundConflicts.add(conflict);
   }
 }

--- a/service/src/main/java/bio/terra/policy/service/pao/graph/model/GraphAttribute.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/graph/model/GraphAttribute.java
@@ -55,11 +55,11 @@ public class GraphAttribute {
     return (containingPao.getObjectId().equals(changedPaoId));
   }
 
-  public void setNewConflict(UUID conflict) {
+  public void addNewConflict(UUID conflict) {
     newConflicts.add(conflict);
   }
 
-  public void setReFoundConflict(UUID conflict) {
+  public void addReFoundConflict(UUID conflict) {
     reFoundConflicts.add(conflict);
   }
 }

--- a/service/src/main/java/bio/terra/policy/service/pao/graph/model/GraphAttribute.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/graph/model/GraphAttribute.java
@@ -2,64 +2,60 @@ package bio.terra.policy.service.pao.graph.model;
 
 import bio.terra.policy.common.model.PolicyInput;
 import bio.terra.policy.service.pao.model.Pao;
-
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
 public class GraphAttribute {
-    private PolicyInput policyInput; // the attribute
-    private final UUID containingPaoId; // the PAO it comes from
-    private final Set<UUID> existingConflicts;
-    private final Set<UUID> newConflicts;
+  private PolicyInput policyInput; // the attribute
+  private final Pao containingPao; // the PAO it comes from
+  private final Set<UUID> existingConflicts; // re-found conflicts
+  private final Set<UUID> newConflicts; // new conflicts
 
-    public GraphAttribute(UUID containingPaoId, PolicyInput policyInput) {
-        this.containingPaoId = containingPaoId;
-        this.policyInput = policyInput.duplicateWithoutConflicts();
-        existingConflicts = policyInput.getConflicts();
-        newConflicts = new HashSet<>();
-    }
+  public GraphAttribute(Pao containingPao, PolicyInput policyInput) {
+    this.containingPao = containingPao;
+    this.policyInput = policyInput.duplicateWithoutConflicts();
+    existingConflicts = new HashSet<>();
+    newConflicts = new HashSet<>();
+  }
 
-    public void appendNewConflicts(List<GraphAttributeConflict> conflicts) {
-        for (UUID newConflict : newConflicts) {
-            conflicts.add(new GraphAttributeConflict(containingPaoId, newConflict, policyInput.getPolicyName()));
-        }
-    }
+  public PolicyInput getPolicyInput() {
+    return policyInput;
+  }
 
-    public PolicyInput getPolicyInput() {
-        return policyInput;
-    }
+  public void setPolicyInput(PolicyInput policyInput) {
+    this.policyInput = policyInput;
+  }
 
-    public void setPolicyInput(PolicyInput policyInput) {
-        this.policyInput = policyInput;
-    }
+  public Pao getContainingPao() {
+    return containingPao;
+  }
 
-    public UUID getContainingPaoId() {
-        return containingPaoId;
-    }
+  public Set<UUID> getExistingConflicts() {
+    return existingConflicts;
+  }
 
-    public Set<UUID> getExistingConflicts() {
-        return existingConflicts;
-    }
+  public Set<UUID> getNewConflicts() {
+    return newConflicts;
+  }
 
-    public Set<UUID> getNewConflicts() {
-        return newConflicts;
-    }
+  public boolean hasExistingConflict() {
+    return !existingConflicts.isEmpty();
+  }
 
-    public boolean hasExistingConflict() {
-        return !existingConflicts.isEmpty();
-    }
+  public boolean hasNewConflict() {
+    return !newConflicts.isEmpty();
+  }
 
-    public boolean hasNewConflict() {
-        return !newConflicts.isEmpty();
-    }
+  public boolean isChanged(UUID changedPaoId) {
+    return (containingPao.equals(changedPaoId));
+  }
 
-    public boolean isChanged(UUID changedPaoId) {
-        return (containingPaoId.equals(changedPaoId));
-    }
+  public void setNewConflict(UUID conflict) {
+    newConflicts.add(conflict);
+  }
 
-    public void setNewConflict(UUID conflict) {
-        newConflicts.add(conflict);
-    }
+  public void setExistingConflict(UUID conflict) {
+    existingConflicts.add(conflict);
+  }
 }

--- a/service/src/main/java/bio/terra/policy/service/pao/graph/model/GraphAttribute.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/graph/model/GraphAttribute.java
@@ -1,0 +1,65 @@
+package bio.terra.policy.service.pao.graph.model;
+
+import bio.terra.policy.common.model.PolicyInput;
+import bio.terra.policy.service.pao.model.Pao;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+public class GraphAttribute {
+    private PolicyInput policyInput; // the attribute
+    private final UUID containingPaoId; // the PAO it comes from
+    private final Set<UUID> existingConflicts;
+    private final Set<UUID> newConflicts;
+
+    public GraphAttribute(UUID containingPaoId, PolicyInput policyInput) {
+        this.containingPaoId = containingPaoId;
+        this.policyInput = policyInput.duplicateWithoutConflicts();
+        existingConflicts = policyInput.getConflicts();
+        newConflicts = new HashSet<>();
+    }
+
+    public void appendNewConflicts(List<GraphAttributeConflict> conflicts) {
+        for (UUID newConflict : newConflicts) {
+            conflicts.add(new GraphAttributeConflict(containingPaoId, newConflict, policyInput.getPolicyName()));
+        }
+    }
+
+    public PolicyInput getPolicyInput() {
+        return policyInput;
+    }
+
+    public void setPolicyInput(PolicyInput policyInput) {
+        this.policyInput = policyInput;
+    }
+
+    public UUID getContainingPaoId() {
+        return containingPaoId;
+    }
+
+    public Set<UUID> getExistingConflicts() {
+        return existingConflicts;
+    }
+
+    public Set<UUID> getNewConflicts() {
+        return newConflicts;
+    }
+
+    public boolean hasExistingConflict() {
+        return !existingConflicts.isEmpty();
+    }
+
+    public boolean hasNewConflict() {
+        return !newConflicts.isEmpty();
+    }
+
+    public boolean isChanged(UUID changedPaoId) {
+        return (containingPaoId.equals(changedPaoId));
+    }
+
+    public void setNewConflict(UUID conflict) {
+        newConflicts.add(conflict);
+    }
+}

--- a/service/src/main/java/bio/terra/policy/service/pao/graph/model/GraphAttributeConflict.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/graph/model/GraphAttributeConflict.java
@@ -1,0 +1,7 @@
+package bio.terra.policy.service.pao.graph.model;
+
+import bio.terra.policy.common.model.PolicyName;
+
+import java.util.UUID;
+
+public record GraphAttributeConflict(UUID containingPaoId, UUID conflictingPaoId, PolicyName policyName) {}

--- a/service/src/main/java/bio/terra/policy/service/pao/graph/model/GraphAttributeConflict.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/graph/model/GraphAttributeConflict.java
@@ -1,7 +1,0 @@
-package bio.terra.policy.service.pao.graph.model;
-
-import bio.terra.policy.common.model.PolicyName;
-
-import java.util.UUID;
-
-public record GraphAttributeConflict(UUID containingPaoId, UUID conflictingPaoId, PolicyName policyName) {}

--- a/service/src/main/java/bio/terra/policy/service/pao/graph/model/GraphAttributeSet.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/graph/model/GraphAttributeSet.java
@@ -1,0 +1,50 @@
+package bio.terra.policy.service.pao.graph.model;
+
+import bio.terra.policy.common.model.PolicyInput;
+import bio.terra.policy.common.model.PolicyInputs;
+import bio.terra.policy.service.pao.model.Pao;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Representation of the attribute set for purposes of walking the graph.
+ */
+public class GraphAttributeSet {
+    private final Map<String, GraphAttribute> attributeSet;
+
+    public GraphAttributeSet() {
+        this.attributeSet = new HashMap<>();
+    }
+
+    public GraphAttributeSet(UUID paoId, PolicyInputs inputs) {
+        this.attributeSet = new HashMap<>();
+        for (PolicyInput input : inputs.getInputs().values()) {
+            attributeSet.put(input.getKey(), new GraphAttribute(paoId, input));
+        }
+    }
+
+    public Collection<GraphAttribute> getAttributes() {
+        return attributeSet.values();
+    }
+
+    public void putAttribute(GraphAttribute graphAttribute) {
+        attributeSet.put(graphAttribute.getPolicyInput().getKey(), graphAttribute);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof GraphAttributeSet)) return false;
+        GraphAttributeSet that = (GraphAttributeSet) o;
+        return Objects.equals(attributeSet, that.attributeSet);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(attributeSet);
+    }
+}

--- a/service/src/main/java/bio/terra/policy/service/pao/graph/model/GraphAttributeSet.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/graph/model/GraphAttributeSet.java
@@ -42,7 +42,7 @@ public class GraphAttributeSet {
   public PolicyInputs makeAttributeSet() {
     var inputs = new PolicyInputs();
     for (GraphAttribute attribute : getAttributes()) {
-      Set<UUID> combinedConflicts = new HashSet<>(attribute.getExistingConflicts());
+      Set<UUID> combinedConflicts = new HashSet<>(attribute.getReFoundConflicts());
       combinedConflicts.addAll(attribute.getNewConflicts());
       var input =
           new PolicyInput(

--- a/service/src/main/java/bio/terra/policy/service/pao/graph/model/GraphAttributeSet.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/graph/model/GraphAttributeSet.java
@@ -3,48 +3,67 @@ package bio.terra.policy.service.pao.graph.model;
 import bio.terra.policy.common.model.PolicyInput;
 import bio.terra.policy.common.model.PolicyInputs;
 import bio.terra.policy.service.pao.model.Pao;
-
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 
-/**
- * Representation of the attribute set for purposes of walking the graph.
- */
+/** Representation of the attribute set for purposes of walking the graph. */
 public class GraphAttributeSet {
-    private final Map<String, GraphAttribute> attributeSet;
+  private final Map<String, GraphAttribute> attributeSet;
 
-    public GraphAttributeSet() {
-        this.attributeSet = new HashMap<>();
-    }
+  public GraphAttributeSet() {
+    this.attributeSet = new HashMap<>();
+  }
 
-    public GraphAttributeSet(UUID paoId, PolicyInputs inputs) {
-        this.attributeSet = new HashMap<>();
-        for (PolicyInput input : inputs.getInputs().values()) {
-            attributeSet.put(input.getKey(), new GraphAttribute(paoId, input));
-        }
+  public GraphAttributeSet(Pao pao, PolicyInputs inputs) {
+    this.attributeSet = new HashMap<>();
+    for (PolicyInput input : inputs.getInputs().values()) {
+      attributeSet.put(input.getKey(), new GraphAttribute(pao, input));
     }
+  }
 
-    public Collection<GraphAttribute> getAttributes() {
-        return attributeSet.values();
-    }
+  public Collection<GraphAttribute> getAttributes() {
+    return attributeSet.values();
+  }
 
-    public void putAttribute(GraphAttribute graphAttribute) {
-        attributeSet.put(graphAttribute.getPolicyInput().getKey(), graphAttribute);
-    }
+  public void putAttribute(GraphAttribute graphAttribute) {
+    attributeSet.put(graphAttribute.getPolicyInput().getKey(), graphAttribute);
+  }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof GraphAttributeSet)) return false;
-        GraphAttributeSet that = (GraphAttributeSet) o;
-        return Objects.equals(attributeSet, that.attributeSet);
+  /**
+   * Make a policy attribute set from the graph attribute set
+   *
+   * @return new attribute set
+   */
+  public PolicyInputs makeAttributeSet() {
+    var inputs = new PolicyInputs();
+    for (GraphAttribute attribute : getAttributes()) {
+      Set<UUID> combinedConflicts = new HashSet<>(attribute.getExistingConflicts());
+      combinedConflicts.addAll(attribute.getNewConflicts());
+      var input =
+          new PolicyInput(
+              attribute.getPolicyInput().getPolicyName(),
+              attribute.getPolicyInput().getAdditionalData(),
+              combinedConflicts);
+      inputs.addInput(input);
     }
+    return inputs;
+  }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(attributeSet);
-    }
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof GraphAttributeSet)) return false;
+    GraphAttributeSet that = (GraphAttributeSet) o;
+    return Objects.equals(attributeSet, that.attributeSet);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(attributeSet);
+  }
 }

--- a/service/src/main/java/bio/terra/policy/service/pao/graph/model/GraphNode.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/graph/model/GraphNode.java
@@ -56,6 +56,10 @@ public class GraphNode {
     this.effectiveAttributeSet = effectiveAttributeSet;
   }
 
+  public GraphAttributeSet getObjectAttributeSet() {
+    return objectAttributeSet;
+  }
+
   public PolicyInputs getPolicyAttributes() {
     return objectAttributeSet.makeAttributeSet();
   }

--- a/service/src/main/java/bio/terra/policy/service/pao/graph/model/GraphNode.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/graph/model/GraphNode.java
@@ -3,66 +3,76 @@ package bio.terra.policy.service.pao.graph.model;
 import bio.terra.policy.service.pao.model.Pao;
 import java.util.List;
 
+/**
+ * The GraphNode represents one policy attribute object (PAO) in TPS.
+
+ */
 public class GraphNode {
-  private Pao initialPao; // starting Pao - typically from the database
-  private Pao computePao; // Pao being computed in the graph walk
+  private Pao pao; // Pao being computed in the graph walk
   private List<GraphNode> sources;
   private List<GraphNode> dependents;
   private boolean modified; // true means something has been changed; false means no change
   private boolean
       newConflict; // true means we have computed a new conflict; false means no new conflict
+  // TODO: Do we need newConflict, or should we scan the effectiveAttributeSet for the answer instead.
 
-  public Pao getInitialPao() {
-    return initialPao;
+  private GraphAttributeSet effectiveAttributeSet;
+  private GraphAttributeSet objectAttributeSet;
+
+  public GraphNode(Pao pao, boolean isModified) {
+    this.pao = pao;
+    this.effectiveAttributeSet = new GraphAttributeSet(pao.getObjectId(), pao.getEffectiveAttributes());
+    this.objectAttributeSet = new GraphAttributeSet(pao.getObjectId(), pao.getAttributes());
+    this.modified = isModified;
+    this.newConflict = false;
   }
 
-  public GraphNode setInitialPao(Pao initialPao) {
-    this.initialPao = initialPao;
-    return this;
-  }
-
-  public Pao getComputePao() {
-    return computePao;
-  }
-
-  public GraphNode setComputePao(Pao computePao) {
-    this.computePao = computePao;
-    return this;
+  public Pao getPao() {
+    return pao;
   }
 
   public List<GraphNode> getSources() {
     return sources;
   }
 
-  public GraphNode setSources(List<GraphNode> sources) {
+  public void setSources(List<GraphNode> sources) {
     this.sources = sources;
-    return this;
   }
 
   public List<GraphNode> getDependents() {
     return dependents;
   }
 
-  public GraphNode setDependents(List<GraphNode> dependents) {
+  public void setDependents(List<GraphNode> dependents) {
     this.dependents = dependents;
-    return this;
   }
 
   public boolean isModified() {
     return modified;
   }
 
-  public GraphNode setModified(boolean modified) {
+  public void setModified(boolean modified) {
     this.modified = modified;
-    return this;
   }
 
   public boolean isNewConflict() {
     return newConflict;
   }
 
-  public GraphNode setNewConflict(boolean newConflict) {
+  public void setNewConflict(boolean newConflict) {
     this.newConflict = newConflict;
-    return this;
   }
+
+  public GraphAttributeSet getEffectiveAttributeSet() {
+    return effectiveAttributeSet;
+  }
+
+  public void setEffectiveAttributeSet(GraphAttributeSet effectiveAttributeSet) {
+    this.effectiveAttributeSet = effectiveAttributeSet;
+  }
+
+  public GraphAttributeSet getObjectAttributeSet() {
+    return objectAttributeSet;
+  }
+
 }

--- a/service/src/main/java/bio/terra/policy/service/pao/graph/model/GraphNode.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/graph/model/GraphNode.java
@@ -1,30 +1,23 @@
 package bio.terra.policy.service.pao.graph.model;
 
+import bio.terra.policy.common.model.PolicyInputs;
 import bio.terra.policy.service.pao.model.Pao;
 import java.util.List;
 
-/**
- * The GraphNode represents one policy attribute object (PAO) in TPS.
-
- */
+/** The GraphNode represents one policy attribute object (PAO) in TPS. */
 public class GraphNode {
-  private Pao pao; // Pao being computed in the graph walk
+  private final Pao pao; // Pao being computed in the graph walk
+  private final GraphAttributeSet objectAttributeSet;
+  private GraphAttributeSet effectiveAttributeSet;
   private List<GraphNode> sources;
   private List<GraphNode> dependents;
   private boolean modified; // true means something has been changed; false means no change
-  private boolean
-      newConflict; // true means we have computed a new conflict; false means no new conflict
-  // TODO: Do we need newConflict, or should we scan the effectiveAttributeSet for the answer instead.
-
-  private GraphAttributeSet effectiveAttributeSet;
-  private GraphAttributeSet objectAttributeSet;
 
   public GraphNode(Pao pao, boolean isModified) {
     this.pao = pao;
-    this.effectiveAttributeSet = new GraphAttributeSet(pao.getObjectId(), pao.getEffectiveAttributes());
-    this.objectAttributeSet = new GraphAttributeSet(pao.getObjectId(), pao.getAttributes());
+    this.effectiveAttributeSet = new GraphAttributeSet(pao, pao.getEffectiveAttributes());
+    this.objectAttributeSet = new GraphAttributeSet(pao, pao.getAttributes());
     this.modified = isModified;
-    this.newConflict = false;
   }
 
   public Pao getPao() {
@@ -55,14 +48,6 @@ public class GraphNode {
     this.modified = modified;
   }
 
-  public boolean isNewConflict() {
-    return newConflict;
-  }
-
-  public void setNewConflict(boolean newConflict) {
-    this.newConflict = newConflict;
-  }
-
   public GraphAttributeSet getEffectiveAttributeSet() {
     return effectiveAttributeSet;
   }
@@ -71,8 +56,11 @@ public class GraphNode {
     this.effectiveAttributeSet = effectiveAttributeSet;
   }
 
-  public GraphAttributeSet getObjectAttributeSet() {
-    return objectAttributeSet;
+  public PolicyInputs getPolicyAttributes() {
+    return objectAttributeSet.makeAttributeSet();
   }
 
+  public PolicyInputs getEffectivePolicyAttributes() {
+    return effectiveAttributeSet.makeAttributeSet();
+  }
 }

--- a/service/src/main/java/bio/terra/policy/service/pao/graph/model/PolicyConflict.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/graph/model/PolicyConflict.java
@@ -4,8 +4,9 @@ import bio.terra.policy.common.model.PolicyName;
 import bio.terra.policy.service.pao.model.Pao;
 
 /**
- * Hold a policy conflict from the graph walk. The dependent is the updated dependent Pao based on
- * the proposed update source. The source is the proposed updated source. The policyName is the name
- * of the policy that has the conflict between the two.
+ * Hold a policy conflict from the graph walk. The `pao` is the pao whose effective attribute set
+ * is being evaluated. The `conflictPao` is the pao that cause the conflict. Note that it is
+ * possible for the `conflictPao` to be the `pao` if the conflict was caused by a change in the
+ * `pao`s attributes.
  */
-public record PolicyConflict(Pao dependent, Pao source, PolicyName policyName) {}
+public record PolicyConflict(Pao pao, Pao conflictPao, PolicyName policyName) {}

--- a/service/src/main/java/bio/terra/policy/service/pao/graph/model/PolicyConflict.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/graph/model/PolicyConflict.java
@@ -4,9 +4,9 @@ import bio.terra.policy.common.model.PolicyName;
 import bio.terra.policy.service.pao.model.Pao;
 
 /**
- * Hold a policy conflict from the graph walk. The `pao` is the pao whose effective attribute set
- * is being evaluated. The `conflictPao` is the pao that cause the conflict. Note that it is
- * possible for the `conflictPao` to be the `pao` if the conflict was caused by a change in the
- * `pao`s attributes.
+ * Hold a policy conflict from the graph walk. The `pao` is the pao whose effective attribute set is
+ * being evaluated. The `conflictPao` is the pao that cause the conflict. Note that it is possible
+ * for the `conflictPao` to be the `pao` if the conflict was caused by a change in the `pao`s
+ * attributes.
  */
 public record PolicyConflict(Pao pao, Pao conflictPao, PolicyName policyName) {}

--- a/service/src/main/java/bio/terra/policy/service/pao/model/Pao.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/model/Pao.java
@@ -79,18 +79,6 @@ public class Pao {
     this.predecessorId = predecessorId;
   }
 
-  public Pao duplicateWithoutConflicts() {
-    return new Builder()
-        .setObjectId(objectId)
-        .setComponent(component)
-        .setObjectType(objectType)
-        .setAttributes(attributes.duplicateWithoutConflicts()) // there are never conflicts in here
-        .setEffectiveAttributes(effectiveAttributes.duplicateWithoutConflicts())
-        .setSourceObjectIds(new HashSet<>(sourceObjectIds))
-        .setPredecessorId(predecessorId)
-        .build();
-  }
-
   public String toShortString() {
     return String.format("%s:%s (%s)", component, objectType, objectId);
   }

--- a/testharness/src/test/java/bio/terra/policy/service/pao/PaoUpdateTest.java
+++ b/testharness/src/test/java/bio/terra/policy/service/pao/PaoUpdateTest.java
@@ -147,7 +147,7 @@ public class PaoUpdateTest extends LibraryTestBase {
     // Link D to None - none should stay in previous state with data policy Y with a conflict
     result = paoService.linkSourcePao(paoNone, paoDid, PaoUpdateMode.FAIL_ON_CONFLICT);
     logger.info("Link D to None result: {}", result);
-    checkConflict(result, paoNone, paoDid, new PolicyName(TEST_NAMESPACE, TEST_DATA_POLICY_Y));
+    checkConflict(result, paoCid, paoDid, new PolicyName(TEST_NAMESPACE, TEST_DATA_POLICY_Y));
 
     // Same comparison as with Link C to None
     resultPao = result.computedPao();
@@ -260,32 +260,21 @@ public class PaoUpdateTest extends LibraryTestBase {
     // Link D to None - none should stay in previous state with data policy Y with a conflict
     result = paoService.linkSourcePao(paoNone, paoDid, PaoUpdateMode.FAIL_ON_CONFLICT);
     logger.info("Link D to None result: {}", result);
+    // Check that we got the right conflict
     assertEquals(1, result.conflicts().size());
     PolicyConflict conflict = result.conflicts().get(0);
-    assertEquals(paoNone, conflict.dependent().getObjectId());
-    // NOTE: The conflict source can be either C or D depending on the order of evaluation.
-    // If D is walked first, then it is the "good" policy and C is the conflict.
-    // If C is walked first, then is is the "good" policy and D is the conflict.
-    // Is that the right thing? An alternative is to sequence the walking, so we walk all existing
-    // sources first and then the new source. The crux is the best way to express the conflict;
-    // Ideally we would say "policy X (with data A) from (PAO: could be the attributes of the node
-    // or
-    // the source), conflicts with policy X from (ditto).
-    assertTrue(
-        conflict.source().getObjectId().equals(paoCid)
-            || conflict.source().getObjectId().equals(paoDid));
+    assertEquals(paoCid, conflict.pao().getObjectId());
+    assertEquals(paoDid, conflict.conflictPao().getObjectId());
     assertEquals(new PolicyName(TEST_NAMESPACE, TEST_DATA_POLICY_Y), conflict.policyName());
-
-    // Same comparison as with Link C to None
-    // Because of the ordering issue above, the resulting policies are not reliably unchanged.
-    // so we cannot test for (TEST_DATA_POLICY_Y, DATA1)
+    // Check that None remains unchanged
     resultPao = result.computedPao();
     assertTrue(resultPao.getSourceObjectIds().contains(paoCid));
     checkForPolicies(
         resultPao,
         makeFlagInput(TEST_FLAG_POLICY_A),
         makeFlagInput(TEST_FLAG_POLICY_B),
-        makeDataInput(TEST_DATA_POLICY_X, DATA1));
+        makeDataInput(TEST_DATA_POLICY_X, DATA1),
+        makeDataInput(TEST_DATA_POLICY_Y, DATA1));
   }
 
   @Test
@@ -384,7 +373,8 @@ public class PaoUpdateTest extends LibraryTestBase {
 
   @Test
   void updatePropagateConflictTest() throws Exception {
-    // Start S1 empty, S2 policy X data2; link to D
+    // Two sources and a dependent
+    // Start S1 empty, S2 policy X data2; link both to D
     // add S1 policy X data1; conflict - try with DRY_RUN, FAIL_ON_CONFLICT, ENFORCE_CONFLICT
     PolicyInput xData2 = makeDataInput(TEST_DATA_POLICY_X, DATA2);
 
@@ -397,6 +387,7 @@ public class PaoUpdateTest extends LibraryTestBase {
     paoService.linkSourcePao(paoDid, paoS1id, PaoUpdateMode.FAIL_ON_CONFLICT);
     paoService.linkSourcePao(paoDid, paoS2id, PaoUpdateMode.FAIL_ON_CONFLICT);
 
+    // Check that the dependent has the right policy
     Pao checkD = paoService.getPao(paoDid);
     checkForPolicies(checkD, xData2);
 
@@ -406,44 +397,41 @@ public class PaoUpdateTest extends LibraryTestBase {
 
     PolicyUpdateResult result =
         paoService.updatePao(paoS1id, conflictPolicy, empty, PaoUpdateMode.DRY_RUN);
-    checkConflict(result, paoDid, paoS2id, new PolicyName(TEST_NAMESPACE, TEST_DATA_POLICY_X));
+    checkConflict(result, paoS2id, paoS1id, new PolicyName(TEST_NAMESPACE, TEST_DATA_POLICY_X));
     checkD = paoService.getPao(paoDid);
     checkForPolicies(checkD, xData2);
     PolicyInput conflicted = checkD.getEffectiveAttributes().getInputs().get(xData2.getKey());
     assertEquals(0, conflicted.getConflicts().size());
 
     // Conflict case - FAIL_ON_CONFLICT
+    // should have the same result as DRY_RUN, since there is a conflict
     result = paoService.updatePao(paoS1id, conflictPolicy, empty, PaoUpdateMode.FAIL_ON_CONFLICT);
-    checkConflict(result, paoDid, paoS2id, new PolicyName(TEST_NAMESPACE, TEST_DATA_POLICY_X));
+    checkConflict(result, paoS2id, paoS1id, new PolicyName(TEST_NAMESPACE, TEST_DATA_POLICY_X));
     checkD = paoService.getPao(paoDid);
     checkForPolicies(checkD, xData2);
     conflicted = checkD.getEffectiveAttributes().getInputs().get(xData2.getKey());
     assertEquals(0, conflicted.getConflicts().size());
 
-    /*
-    TODO[PF-1927] The conflict scheme is not working the way it needs to.
-     Fixing it is outside the scope of this work, but I'll to PF-1927 next!
     // Conflict case - ENFORCE_CONFLICTS
     result = paoService.updatePao(paoS1id, conflictPolicy, empty, PaoUpdateMode.ENFORCE_CONFLICTS);
-    checkConflict(result, paoDid, paoS2id, new PolicyName(TEST_NAMESPACE, TEST_DATA_POLICY_X));
+    checkConflict(result, paoS2id, paoS1id, new PolicyName(TEST_NAMESPACE, TEST_DATA_POLICY_X));
     checkD = paoService.getPao(paoDid);
     checkForPolicies(checkD, xData2);
 
     conflicted = checkD.getEffectiveAttributes().getInputs().get(xData2.getKey());
     assertEquals(1, conflicted.getConflicts().size());
     assertTrue(conflicted.getConflicts().contains(paoS1id));
-     */
   }
 
   private void checkConflict(
       PolicyUpdateResult result,
-      UUID expectedDependent,
-      UUID expectedSource,
+      UUID expectedPaoId,
+      UUID expectedConflictId,
       PolicyName expectedPolicyName) {
     assertEquals(1, result.conflicts().size());
     PolicyConflict conflict = result.conflicts().get(0);
-    assertEquals(expectedDependent, conflict.dependent().getObjectId());
-    assertEquals(expectedSource, conflict.source().getObjectId());
+    assertEquals(expectedPaoId, conflict.pao().getObjectId());
+    assertEquals(expectedConflictId, conflict.conflictPao().getObjectId());
     assertEquals(expectedPolicyName, conflict.policyName());
   }
 

--- a/testharness/src/test/java/bio/terra/policy/service/pao/PaoUpdateTest.java
+++ b/testharness/src/test/java/bio/terra/policy/service/pao/PaoUpdateTest.java
@@ -454,6 +454,22 @@ public class PaoUpdateTest extends LibraryTestBase {
     checkConflictFind(result, paoBid, paoAid, xData1.getPolicyName());
     checkConflictFind(result, paoCid, paoBid, xData1.getPolicyName());
     checkConflictFind(result, paoDid, paoCid, xData1.getPolicyName());
+
+    result =
+        paoService.updatePao(paoAid, conflictPolicy, emptyPolicy, PaoUpdateMode.FAIL_ON_CONFLICT);
+    logger.info("Result: {}", result);
+    assertEquals(3, result.conflicts().size()); // B, C, and D
+    checkConflictFind(result, paoBid, paoAid, xData1.getPolicyName());
+    checkConflictFind(result, paoCid, paoBid, xData1.getPolicyName());
+    checkConflictFind(result, paoDid, paoCid, xData1.getPolicyName());
+
+    result =
+        paoService.updatePao(paoAid, conflictPolicy, emptyPolicy, PaoUpdateMode.ENFORCE_CONFLICTS);
+    logger.info("Result: {}", result);
+    assertEquals(3, result.conflicts().size()); // B, C, and D
+    checkConflictFind(result, paoBid, paoAid, xData1.getPolicyName());
+    checkConflictFind(result, paoCid, paoBid, xData1.getPolicyName());
+    checkConflictFind(result, paoDid, paoCid, xData1.getPolicyName());
   }
 
   private void checkConflictFind(


### PR DESCRIPTION
I rewrote the attribute evaluation to give a consistent result on conflicts and to propagate conflicts through the dependents rather than stopping at the first one.

The code is very close to the algorithm outlined in [Policy Conflict Implementation Notes](https://docs.google.com/document/d/1GUJA_DTPdvigFh9JEcnbd668EBiil6nBQwYLxKK9MXg/edit?resourcekey=0-vOR9fDJIaEvAYquvWHLBeA#heading=h.qet38xi4p78c)

I plan to integrate those notes into the implementation notes markdown as a separate task.

I added classes in the `graph` package to support the walk. Now rather than trying to operate directly on the Pao object, it operates on these graph objects.

@yuhuyoyo I didn't tag you for a review, but feel free to add yourself if you'd like to look at the new code.