### PR TITLE
PF-1966: fix getPao throws EmptyResultDataAccessException when no matching PAO is found

### DIFF
--- a/service/src/main/java/bio/terra/policy/db/PaoDao.java
+++ b/service/src/main/java/bio/terra/policy/db/PaoDao.java
@@ -371,11 +371,11 @@ public class PaoDao {
     MapSqlParameterSource params =
         new MapSqlParameterSource().addValue("object_id", objectId.toString());
 
-    DbPao dbPao = tpsJdbcTemplate.queryForObject(sql, params, DB_PAO_ROW_MAPPER);
-    if (dbPao == null) {
+    List<DbPao> dbPao = tpsJdbcTemplate.query(sql, params, DB_PAO_ROW_MAPPER);
+    if (dbPao.isEmpty()) {
       throw new InternalTpsErrorException("Failed to get DbPao from object id");
     }
-    return dbPao;
+    return dbPao.get(0);
   }
 
   private List<DbPao> getDbPaos(List<UUID> objectIdList) {

--- a/service/src/main/java/bio/terra/policy/db/PaoDao.java
+++ b/service/src/main/java/bio/terra/policy/db/PaoDao.java
@@ -1,6 +1,5 @@
 package bio.terra.policy.db;
 
-import bio.terra.policy.common.exception.InternalTpsErrorException;
 import bio.terra.policy.common.exception.PolicyObjectNotFoundException;
 import bio.terra.policy.common.model.PolicyInput;
 import bio.terra.policy.common.model.PolicyInputs;
@@ -24,7 +23,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DuplicateKeyException;
-import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;

--- a/service/src/main/java/bio/terra/policy/db/PaoDao.java
+++ b/service/src/main/java/bio/terra/policy/db/PaoDao.java
@@ -141,7 +141,7 @@ public class PaoDao {
       MapSqlParameterSource params =
           new MapSqlParameterSource().addValue("object_id", objectId.toString());
       tpsJdbcTemplate.update(sql, params);
-    } catch (EmptyResultDataAccessException e) {
+    } catch (PolicyObjectNotFoundException e) {
       // Delete throws no error on not found
     }
   }
@@ -153,14 +153,10 @@ public class PaoDao {
       readOnly = true,
       transactionManager = "tpsTransactionManager")
   public Pao getPao(UUID objectId) {
-    try {
-      DbPao dbPao = getDbPao(objectId);
-      Map<String, PolicyInputs> attributeSetMap =
-          getAttributeSets(List.of(dbPao.attributeSetId(), dbPao.effectiveSetId()));
-      return Pao.fromDb(dbPao, attributeSetMap);
-    } catch (InternalTpsErrorException e) {
-      throw new PolicyObjectNotFoundException("Policy object not found: " + objectId);
-    }
+    DbPao dbPao = getDbPao(objectId);
+    Map<String, PolicyInputs> attributeSetMap =
+        getAttributeSets(List.of(dbPao.attributeSetId(), dbPao.effectiveSetId()));
+    return Pao.fromDb(dbPao, attributeSetMap);
   }
 
   // -- Graph Walk Methods --
@@ -373,7 +369,7 @@ public class PaoDao {
 
     List<DbPao> dbPao = tpsJdbcTemplate.query(sql, params, DB_PAO_ROW_MAPPER);
     if (dbPao.isEmpty()) {
-      throw new InternalTpsErrorException("Failed to get DbPao from object id");
+      throw new PolicyObjectNotFoundException("Policy object not found: " + objectId);
     }
     return dbPao.get(0);
   }

--- a/service/src/main/java/bio/terra/policy/db/PaoDao.java
+++ b/service/src/main/java/bio/terra/policy/db/PaoDao.java
@@ -158,7 +158,7 @@ public class PaoDao {
       Map<String, PolicyInputs> attributeSetMap =
           getAttributeSets(List.of(dbPao.attributeSetId(), dbPao.effectiveSetId()));
       return Pao.fromDb(dbPao, attributeSetMap);
-    } catch (EmptyResultDataAccessException e) {
+    } catch (InternalTpsErrorException e) {
       throw new PolicyObjectNotFoundException("Policy object not found: " + objectId);
     }
   }

--- a/testharness/src/test/java/bio/terra/policy/service/pao/PaoServiceTest.java
+++ b/testharness/src/test/java/bio/terra/policy/service/pao/PaoServiceTest.java
@@ -2,6 +2,7 @@ package bio.terra.policy.service.pao;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import bio.terra.policy.common.exception.InternalTpsErrorException;
 import bio.terra.policy.common.exception.PolicyObjectNotFoundException;
 import bio.terra.policy.common.model.PolicyInput;
 import bio.terra.policy.common.model.PolicyInputs;
@@ -94,6 +95,9 @@ public class PaoServiceTest extends LibraryTestBase {
 
     assertThrows(
         DuplicateObjectException.class, () -> paoService.clonePao(objectId, destinationObjectId));
+    assertThrows(
+        InternalTpsErrorException.class,
+        () -> paoService.clonePao(UUID.randomUUID(), destinationObjectId));
 
     // Delete
     paoService.deletePao(objectId);

--- a/testharness/src/test/java/bio/terra/policy/service/pao/PaoServiceTest.java
+++ b/testharness/src/test/java/bio/terra/policy/service/pao/PaoServiceTest.java
@@ -2,7 +2,6 @@ package bio.terra.policy.service.pao;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import bio.terra.policy.common.exception.InternalTpsErrorException;
 import bio.terra.policy.common.exception.PolicyObjectNotFoundException;
 import bio.terra.policy.common.model.PolicyInput;
 import bio.terra.policy.common.model.PolicyInputs;

--- a/testharness/src/test/java/bio/terra/policy/service/pao/PaoServiceTest.java
+++ b/testharness/src/test/java/bio/terra/policy/service/pao/PaoServiceTest.java
@@ -96,7 +96,7 @@ public class PaoServiceTest extends LibraryTestBase {
     assertThrows(
         DuplicateObjectException.class, () -> paoService.clonePao(objectId, destinationObjectId));
     assertThrows(
-        InternalTpsErrorException.class,
+        PolicyObjectNotFoundException.class,
         () -> paoService.clonePao(UUID.randomUUID(), destinationObjectId));
 
     // Delete


### PR DESCRIPTION
This came up when trying to clone a workspace PAO when the origin workspace didn't have a PAO. The problem was the query was expecting one result and threw a different exception when there were no matches. This fix lets us throw the internal exception as expected.