### PR TITLE
PF-1951: Implementation for PAO delete

### DIFF
--- a/service/src/main/java/bio/terra/policy/db/DbPao.java
+++ b/service/src/main/java/bio/terra/policy/db/DbPao.java
@@ -12,4 +12,5 @@ public record DbPao(
     PaoObjectType objectType,
     Set<String> sources,
     String attributeSetId,
-    String effectiveSetId) {}
+    String effectiveSetId,
+    boolean deleted) {}

--- a/service/src/main/java/bio/terra/policy/service/pao/PaoService.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/PaoService.java
@@ -5,7 +5,9 @@ import bio.terra.policy.common.exception.InternalTpsErrorException;
 import bio.terra.policy.common.exception.PolicyNotImplementedException;
 import bio.terra.policy.common.model.PolicyInput;
 import bio.terra.policy.common.model.PolicyInputs;
+import bio.terra.policy.db.DbPao;
 import bio.terra.policy.db.PaoDao;
+import bio.terra.policy.service.pao.graph.DeleteWalker;
 import bio.terra.policy.service.pao.graph.Walker;
 import bio.terra.policy.service.pao.graph.model.PolicyConflict;
 import bio.terra.policy.service.pao.model.Pao;
@@ -16,6 +18,7 @@ import bio.terra.policy.service.policy.PolicyMutator;
 import bio.terra.policy.service.policy.model.PolicyUpdateResult;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,7 +69,10 @@ public class PaoService {
 
   public void deletePao(UUID objectId) {
     logger.info("Delete PAO id {}", objectId);
-    paoDao.deletePao(objectId);
+    paoDao.markPaoDeleted(objectId);
+    DeleteWalker walker = new DeleteWalker(paoDao, objectId);
+    Set<DbPao> toRemove = walker.findRemovablePaos();
+    paoDao.deletePaos(toRemove);
   }
 
   public Pao getPao(UUID objectId) {

--- a/service/src/main/java/bio/terra/policy/service/pao/graph/DeleteWalker.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/graph/DeleteWalker.java
@@ -1,0 +1,121 @@
+package bio.terra.policy.service.pao.graph;
+
+import bio.terra.policy.db.DbPao;
+import bio.terra.policy.db.PaoDao;
+import bio.terra.policy.service.pao.graph.model.DeleteGraphNode;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.Set;
+import java.util.UUID;
+
+public class DeleteWalker {
+  private HashMap<UUID, DeleteGraphNode> subgraphMap;
+  private PaoDao paoDao;
+  private UUID rootObjectId;
+
+  public DeleteWalker(PaoDao paoDao, UUID rootObjectId) {
+    subgraphMap = new HashMap<>();
+    this.paoDao = paoDao;
+    this.rootObjectId = rootObjectId;
+  }
+
+  public Set<DbPao> findRemovablePaos() {
+    final Set<UUID> dependents = paoDao.getDependentIds(rootObjectId);
+    final Set<DbPao> result = new HashSet<>();
+
+    if (dependents.isEmpty()) {
+      DbPao dbPao = paoDao.getDbPao(rootObjectId);
+
+      // First Pass: Build a map of all PAOs in our subgraph and note if they are flagged for
+      // deletion.
+      HashMap<UUID, DeleteGraphNode> subgraphMap = new HashMap<>();
+      walkDeleteSubgraph(subgraphMap, dbPao);
+
+      // Second Pass: iterate through our graph, for each PAO:
+      // Recursively check its dependents and verify it's still removable.
+      // If all dependents are flagged for deletion and exist in our known subgraph,
+      // then the PAO is still removable.
+      HashMap<UUID, Set<DbPao>> dependentMap = new HashMap<>();
+      walkDeleteDependents(subgraphMap, dependentMap, dbPao);
+
+      // Finally - remove PAOs that are still removable
+      subgraphMap.forEach(
+          (UUID id, DeleteGraphNode node) -> {
+            if (node.getRemovable()) {
+              result.add(node.getPao());
+            }
+          });
+    }
+
+    return result;
+  }
+
+  /**
+   * Recursively build out a map of which PAOs are in the subgraph and note which PAOs have been
+   * flagged for deletion.
+   *
+   * @param subgraphMap a map of PAO id to dbPao that will be filled in during the recursive calls
+   * @param pao the PAO currently being evaluated. On first call, this would be the root of the
+   *     subgraph.
+   */
+  private void walkDeleteSubgraph(HashMap<UUID, DeleteGraphNode> subgraphMap, DbPao pao) {
+    subgraphMap.put(pao.objectId(), new DeleteGraphNode(pao, pao.deleted()));
+
+    for (var source : pao.sources()) {
+      walkDeleteSubgraph(subgraphMap, paoDao.getDbPao(UUID.fromString(source)));
+    }
+  }
+
+  /**
+   * Recursive call to check all dependents of a given PAO and update the PAOs removability.
+   *
+   * @param subgraphMap a map of PAO id to dbPao. This map gets checked for subgraph membership as
+   *     we recurse through dependents.
+   * @param dependentMap a map of PAO id to all of that PAOs dependents. This serves as a cache and
+   *     is filled in during recursive calls.
+   * @param pao the PAO currently being evaluated. On first call, this would be the root of the
+   *     subgraph.
+   */
+  private void walkDeleteDependents(
+      HashMap<UUID, DeleteGraphNode> subgraphMap,
+      HashMap<UUID, Set<DbPao>> dependentMap,
+      DbPao pao) {
+    HashMap<UUID, DbPao> dependents = new HashMap<>();
+
+    if (pao == null) return;
+
+    if (!dependentMap.containsKey(pao.objectId())) {
+      // use a BFS to build a dependency list
+      Queue<UUID> queue = new LinkedList<>();
+      queue.addAll(paoDao.getDependentIds(pao.objectId()));
+
+      while (!queue.isEmpty()) {
+        UUID depId = queue.poll();
+        if (!dependents.containsKey(depId)) {
+          dependents.put(depId, paoDao.getDbPao(depId));
+        }
+        queue.addAll(paoDao.getDependentIds(depId));
+      }
+
+      dependentMap.put(pao.objectId(), new HashSet<>(dependents.values()));
+    }
+
+    for (var dependent : dependents.values()) {
+      if (!subgraphMap.containsKey(dependent.objectId()) || !dependent.deleted()) {
+        // if any dependent is not part of the subgraph or is not flagged for removal
+        // then the current PAO cannot be removed.
+        subgraphMap.get(pao.objectId()).setRemovable(false);
+        break;
+      }
+    }
+
+    for (var source : pao.sources()) {
+      // recursive step to continue checking all the current PAOs sources
+      // use the subgraphMap so lookup PAOs so that we don't keep querying the db
+      walkDeleteDependents(
+          subgraphMap, dependentMap, subgraphMap.get(UUID.fromString(source)).getPao());
+    }
+  }
+}

--- a/service/src/main/java/bio/terra/policy/service/pao/graph/model/DeleteGraphNode.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/graph/model/DeleteGraphNode.java
@@ -1,0 +1,25 @@
+package bio.terra.policy.service.pao.graph.model;
+
+import bio.terra.policy.db.DbPao;
+
+public class DeleteGraphNode {
+  private final DbPao pao;
+  private Boolean isRemovable;
+
+  public DeleteGraphNode(DbPao pao, Boolean isRemovable) {
+    this.pao = pao;
+    this.isRemovable = isRemovable;
+  }
+
+  public DbPao getPao() {
+    return pao;
+  }
+
+  public Boolean getRemovable() {
+    return isRemovable;
+  }
+
+  public void setRemovable(Boolean removable) {
+    isRemovable = removable;
+  }
+}

--- a/service/src/main/java/bio/terra/policy/service/pao/model/Pao.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/model/Pao.java
@@ -16,6 +16,7 @@ public class Pao {
   private PolicyInputs attributes;
   private PolicyInputs effectiveAttributes;
   private Set<UUID> sourceObjectIds;
+  private boolean deleted;
 
   public Pao(
       UUID objectId,
@@ -23,13 +24,15 @@ public class Pao {
       PaoObjectType objectType,
       PolicyInputs attributes,
       PolicyInputs effectiveAttributes,
-      Set<UUID> sourceObjectIds) {
+      Set<UUID> sourceObjectIds,
+      boolean deleted) {
     this.objectId = objectId;
     this.component = component;
     this.objectType = objectType;
     this.attributes = attributes;
     this.effectiveAttributes = effectiveAttributes;
     this.sourceObjectIds = sourceObjectIds;
+    this.deleted = deleted;
   }
 
   public UUID getObjectId() {
@@ -68,6 +71,14 @@ public class Pao {
     this.sourceObjectIds = sourceObjectIds;
   }
 
+  public boolean getDeleted() {
+    return deleted;
+  }
+
+  public void setDeleted(boolean deleted) {
+    this.deleted = deleted;
+  }
+
   public String toShortString() {
     return String.format("%s:%s (%s)", component, objectType, objectId);
   }
@@ -81,6 +92,7 @@ public class Pao {
         .add("attributes=" + attributes)
         .add("effectiveAttributes=" + effectiveAttributes)
         .add("sourceObjectIds=" + sourceObjectIds)
+        .add("deleted=" + deleted)
         .toString();
   }
 
@@ -93,6 +105,7 @@ public class Pao {
             dbPao.sources().stream().map(UUID::fromString).collect(Collectors.toSet()))
         .setAttributes(attributeSetMap.get(dbPao.attributeSetId()))
         .setEffectiveAttributes(attributeSetMap.get(dbPao.effectiveSetId()))
+        .setDeleted(dbPao.deleted())
         .build();
   }
 
@@ -103,6 +116,7 @@ public class Pao {
     private PolicyInputs attributes;
     private PolicyInputs effectiveAttributes;
     private Set<UUID> sourceObjectIds;
+    private boolean deleted;
 
     public Builder setObjectId(UUID objectId) {
       this.objectId = objectId;
@@ -124,6 +138,11 @@ public class Pao {
       return this;
     }
 
+    public Builder setDeleted(boolean deleted) {
+      this.deleted = deleted;
+      return this;
+    }
+
     public Builder setEffectiveAttributes(PolicyInputs effectiveAttributes) {
       this.effectiveAttributes = effectiveAttributes;
       return this;
@@ -139,7 +158,7 @@ public class Pao {
         sourceObjectIds = new HashSet<>();
       }
       return new Pao(
-          objectId, component, objectType, attributes, effectiveAttributes, sourceObjectIds);
+          objectId, component, objectType, attributes, effectiveAttributes, sourceObjectIds, deleted);
     }
   }
 }

--- a/service/src/main/java/bio/terra/policy/service/pao/model/Pao.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/model/Pao.java
@@ -158,7 +158,13 @@ public class Pao {
         sourceObjectIds = new HashSet<>();
       }
       return new Pao(
-          objectId, component, objectType, attributes, effectiveAttributes, sourceObjectIds, deleted);
+          objectId,
+          component,
+          objectType,
+          attributes,
+          effectiveAttributes,
+          sourceObjectIds,
+          deleted);
     }
   }
 }

--- a/service/src/main/resources/policydb/changelog.xml
+++ b/service/src/main/resources/policydb/changelog.xml
@@ -7,4 +7,5 @@
   <include file="changesets/20220811_attribute_set_index.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20220812_pao_features.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20220909_remove_predecessor.yaml" relativeToChangelogFile="true"/>
+  <include file="changesets/20220830_pao_deleted.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/service/src/main/resources/policydb/changesets/20220830_pao_deleted.yaml
+++ b/service/src/main/resources/policydb/changesets/20220830_pao_deleted.yaml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+  - changeSet:
+      id: pao_deleted
+      author: mikenev
+      changes:
+      - addColumn:
+          tableName: policy_object
+          columns:
+            - column:
+                name: deleted
+                type: boolean
+                remarks: Indicates the PAO has been deleted

--- a/testharness/src/test/java/bio/terra/policy/service/pao/PaoDeleteTest.java
+++ b/testharness/src/test/java/bio/terra/policy/service/pao/PaoDeleteTest.java
@@ -1,0 +1,222 @@
+package bio.terra.policy.service.pao;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import bio.terra.policy.common.exception.PolicyObjectNotFoundException;
+import bio.terra.policy.common.model.PolicyInput;
+import bio.terra.policy.common.model.PolicyInputs;
+import bio.terra.policy.service.pao.model.Pao;
+import bio.terra.policy.service.pao.model.PaoComponent;
+import bio.terra.policy.service.pao.model.PaoObjectType;
+import bio.terra.policy.service.pao.model.PaoUpdateMode;
+import bio.terra.policy.testutils.LibraryTestBase;
+import java.util.Collections;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class PaoDeleteTest extends LibraryTestBase {
+  private static final String TERRA = "terra";
+  private static final String GROUP_CONSTRAINT = "group-constraint";
+  private static final String REGION_CONSTRAINT = "region-constraint";
+  private static final String GROUP = "group";
+  private static final String REGION = "region";
+  private static final String DDGROUP = "ddgroup";
+  private static final String US_REGION = "US";
+
+  @Autowired private PaoService paoService;
+
+  /**
+   * A standalone PAO with no sources and no dependents should be removed from the DB.
+   *
+   * @throws Exception
+   */
+  @Test
+  void deletePaoRemovesFromDb() throws Exception {
+    var objectId = UUID.randomUUID();
+    createDefaultPao(objectId);
+
+    // Retrieve and validate
+    Pao pao = paoService.getPao(objectId);
+    assertEquals(objectId, pao.getObjectId());
+
+    // Delete removes the PAO from the DB
+    paoService.deletePao(objectId);
+    assertThrows(PolicyObjectNotFoundException.class, () -> paoService.getPao(objectId));
+  }
+
+  /**
+   * If the PAO being deleted is referenced as a source by another PAO, then it doesn't get removed
+   * from the graph but gets marked as deleted.
+   *
+   * <pre>
+   *     {dependentPao}
+   *          |
+   *     {sourcePao} <-- delete here
+   * </pre>
+   *
+   * Result should be both PAOs are still in the graph, sourcePao is marked as deleted.
+   */
+  @Test
+  void deletePaoMarksDeleted() {
+    var sourcePaoId = UUID.randomUUID();
+    var dependentPaoId = UUID.randomUUID();
+    createDefaultPao(sourcePaoId);
+    createDefaultPao(dependentPaoId);
+    paoService.linkSourcePao(dependentPaoId, sourcePaoId, PaoUpdateMode.FAIL_ON_CONFLICT);
+
+    // Call delete on the source PAO
+    paoService.deletePao(sourcePaoId);
+
+    // Since sourcePao has a dependent, it should be flagged as 'deleted' but should not be removed
+    // from the db.
+    final var sourcePao = paoService.getPao(sourcePaoId);
+    assertNotNull(sourcePao);
+    assertEquals(sourcePaoId, sourcePao.getObjectId());
+    assertTrue(sourcePao.getDeleted());
+
+    // Dependent should still link back to the source and not be deleted.
+    final var dependentPao = paoService.getPao(dependentPaoId);
+    assertNotNull(dependentPao);
+    assertTrue(dependentPao.getSourceObjectIds().contains(sourcePaoId));
+    assertFalse(dependentPao.getDeleted());
+  }
+
+  /**
+   * In this case, the deleted PAO has two sources, one of which was previously flagged as deleted.
+   *
+   * <pre>
+   *     {targetPao} <-- delete second
+   *      /         \
+   * {sourcePao1}  {sourcePao2*} <-- delete first
+   *                  \
+   *                {sourcePao3}
+   * </pre>
+   *
+   * The result should be that targetPao and sourcePao2 should be removed from the db. The other
+   * PAOs should remain.
+   */
+  @Test
+  void deletePaoRemovesPreviouslyFlaggedSource() throws Exception {
+    var targetObjectId = UUID.randomUUID();
+    var source1ObjectId = UUID.randomUUID();
+    var source2ObjectId = UUID.randomUUID();
+    var source3ObjectId = UUID.randomUUID();
+    createDefaultPao(targetObjectId);
+    createDefaultPao(source1ObjectId);
+    createDefaultPao(source2ObjectId);
+    createDefaultPao(source3ObjectId);
+
+    paoService.linkSourcePao(targetObjectId, source1ObjectId, PaoUpdateMode.FAIL_ON_CONFLICT);
+    paoService.linkSourcePao(targetObjectId, source2ObjectId, PaoUpdateMode.FAIL_ON_CONFLICT);
+    paoService.linkSourcePao(targetObjectId, source3ObjectId, PaoUpdateMode.FAIL_ON_CONFLICT);
+
+    // Call delete on sourcePao2
+    paoService.deletePao(source2ObjectId);
+    var pao = paoService.getPao(source2ObjectId);
+    assertNotNull(pao);
+    assertTrue(pao.getDeleted());
+
+    // Call delete on targetPao
+    paoService.deletePao(targetObjectId);
+
+    // targetPao and sourcePao2 should be deleted
+    assertThrows(PolicyObjectNotFoundException.class, () -> paoService.getPao(targetObjectId));
+    assertThrows(PolicyObjectNotFoundException.class, () -> paoService.getPao(source2ObjectId));
+
+    // sourcePao1 and sourcePao3 should not be
+    assertNotNull(paoService.getPao(source1ObjectId));
+    assertNotNull(paoService.getPao(source3ObjectId));
+  }
+
+  /**
+   * Recursive test: deleting a Pao should visit all source Paos recursively and apply the delete
+   * logic on them.
+   *
+   * <pre>
+   *                    {targetPao#} <-- delete last
+   *                    /       \
+   * delete 2nd--> {pao2#}     {pao3}
+   *                /   \
+   *            {pao4}   \    {pao6}
+   *                      \   /
+   *                    {pao5*}  <-- delete 1st
+   *                       |
+   *                    {pao7}
+   * </pre>
+   *
+   * The result should be that the PAO marked with a * should be flagged as deleted. All PAOs marked
+   * with a # should be removed from the DB
+   */
+  @Test
+  void deleteRecursive() throws Exception {
+    var targetObjectId = UUID.randomUUID();
+    var pao2Id = UUID.randomUUID();
+    var pao3Id = UUID.randomUUID();
+    var pao4Id = UUID.randomUUID();
+    var pao5Id = UUID.randomUUID();
+    var pao6Id = UUID.randomUUID();
+    var pao7Id = UUID.randomUUID();
+    createDefaultPao(targetObjectId);
+    createDefaultPao(pao2Id);
+    createDefaultPao(pao3Id);
+    createDefaultPao(pao4Id);
+    createDefaultPao(pao5Id);
+    createDefaultPao(pao6Id);
+    createDefaultPao(pao7Id);
+
+    paoService.linkSourcePao(targetObjectId, pao2Id, PaoUpdateMode.FAIL_ON_CONFLICT);
+    paoService.linkSourcePao(targetObjectId, pao3Id, PaoUpdateMode.FAIL_ON_CONFLICT);
+
+    paoService.linkSourcePao(pao2Id, pao4Id, PaoUpdateMode.FAIL_ON_CONFLICT);
+    paoService.linkSourcePao(pao2Id, pao5Id, PaoUpdateMode.FAIL_ON_CONFLICT);
+
+    paoService.linkSourcePao(pao6Id, pao5Id, PaoUpdateMode.FAIL_ON_CONFLICT);
+
+    paoService.linkSourcePao(pao5Id, pao7Id, PaoUpdateMode.FAIL_ON_CONFLICT);
+
+    // Call first delete to mark Pao5 deleted.
+    paoService.deletePao(pao5Id);
+    var pao = paoService.getPao(pao5Id);
+    assertTrue(pao.getDeleted());
+
+    // call second delete to mark Pao2 deleted
+    paoService.deletePao(pao2Id);
+    pao = paoService.getPao(pao2Id);
+    assertTrue(pao.getDeleted());
+
+    // call final delete to remove targetPao
+    paoService.deletePao(targetObjectId);
+
+    // These PAOs should have been removed from the DB
+    assertThrows(PolicyObjectNotFoundException.class, () -> paoService.getPao(targetObjectId));
+    assertThrows(PolicyObjectNotFoundException.class, () -> paoService.getPao(pao2Id));
+
+    // This PAO should be marked as deleted but not removed from the db
+    final var pao5 = paoService.getPao(pao5Id);
+    assertNotNull(pao5);
+    assertTrue(pao5.getDeleted());
+
+    // These PAOs should still exist
+    assertNotNull(paoService.getPao(pao3Id));
+    assertNotNull(paoService.getPao(pao4Id));
+    assertNotNull(paoService.getPao(pao6Id));
+    assertNotNull(paoService.getPao(pao7Id));
+  }
+
+  private void createDefaultPao(UUID objectId) {
+    var groupPolicy =
+        PolicyInput.createFromMap(
+            TERRA, GROUP_CONSTRAINT, Collections.singletonMap(GROUP, DDGROUP));
+    var regionPolicy =
+        PolicyInput.createFromMap(
+            TERRA, REGION_CONSTRAINT, Collections.singletonMap(REGION, US_REGION));
+
+    var inputs = new PolicyInputs();
+    inputs.addInput(groupPolicy);
+    inputs.addInput(regionPolicy);
+
+    // Create a PAO
+    paoService.createPao(objectId, PaoComponent.WSM, PaoObjectType.WORKSPACE, inputs);
+  }
+}


### PR DESCRIPTION
Added logic for deleting PAOs. When calling delete on a PAO:
If the target is not referenced as a policy source, then we remove the PAO from the graph. Also, recursively inspect its sources to see if they now have no dependents. If not, they can be removed if they were previously flagged as deleted.
If the target was referenced as a source, then flag it as deleted but leave it in the graph.