### PR TITLE
[PF-1971] Remove predecessor update clone semantics and rename it to merge

### DIFF
--- a/service/src/main/java/bio/terra/policy/db/DbPao.java
+++ b/service/src/main/java/bio/terra/policy/db/DbPao.java
@@ -12,5 +12,4 @@ public record DbPao(
     PaoObjectType objectType,
     Set<String> sources,
     String attributeSetId,
-    String effectiveSetId,
-    UUID predecessorId) {}
+    String effectiveSetId) {}

--- a/service/src/main/java/bio/terra/policy/service/pao/PaoService.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/PaoService.java
@@ -2,6 +2,7 @@ package bio.terra.policy.service.pao;
 
 import bio.terra.policy.common.exception.DirectConflictException;
 import bio.terra.policy.common.exception.InternalTpsErrorException;
+import bio.terra.policy.common.exception.PolicyNotImplementedException;
 import bio.terra.policy.common.model.PolicyInput;
 import bio.terra.policy.common.model.PolicyInputs;
 import bio.terra.policy.db.PaoDao;
@@ -37,10 +38,18 @@ public class PaoService {
   }
 
   public void clonePao(UUID sourceObjectId, UUID destinationObjectId) {
-    logger.info("Clone PAO id {} to {}", sourceObjectId, destinationObjectId);
-    paoDao.clonePao(sourceObjectId, destinationObjectId);
+    throw new PolicyNotImplementedException("Deprecated method. Here until we change the WSM call");
   }
 
+  /**
+   * Create a policy attribute object
+   *
+   * @param objectId UUID of the object - client-relevant
+   * @param component identity of the component, so we know what component owns UUID
+   * @param objectType type of object in the component, so the component knows where to look up the
+   *     UUID
+   * @param inputs policy attributes
+   */
   public void createPao(
       UUID objectId, PaoComponent component, PaoObjectType objectType, PolicyInputs inputs) {
     logger.info(
@@ -83,7 +92,8 @@ public class PaoService {
     if (updateMode == PaoUpdateMode.ENFORCE_CONFLICTS) {
       throw new InternalTpsErrorException("ENFORCE_CONFLICTS is not allowed on listSourcePao");
     }
-    logger.info("LinkSourcePao: dependent {} source {}", objectId, sourceObjectId);
+    logger.info(
+        "LinkSourcePao: dependent {} source {} mode {}", objectId, sourceObjectId, updateMode);
 
     Pao targetPao = paoDao.getPao(objectId);
     boolean newSource = targetPao.getSourceObjectIds().add(sourceObjectId);
@@ -103,6 +113,49 @@ public class PaoService {
     }
 
     return new PolicyUpdateResult(targetPao, conflicts);
+  }
+
+  /**
+   * Merge policies from one PAO into another PAO. Sometimes, like a workspace clone, we want to
+   * take source policies and apply them to a destination.
+   *
+   * @param sourceObjectId source PAO of the policies
+   * @param destinationObjectId PAO we should merge them into
+   * @param updateMode DRY_RUN or FAIL_ON_CONFLICT
+   * @return result of the merge - destination PAO and any policy conflicts
+   */
+  public PolicyUpdateResult mergeFromPao(
+      UUID sourceObjectId, UUID destinationObjectId, PaoUpdateMode updateMode) {
+    if (updateMode == PaoUpdateMode.ENFORCE_CONFLICTS) {
+      throw new InternalTpsErrorException("ENFORCE_CONFLICTS is not allowed on listSourcePao");
+    }
+    logger.info(
+        "Merge from PAO id {} to {} mode {}", sourceObjectId, destinationObjectId, updateMode);
+
+    // Step 0: get the paos. This will throw if they are not present
+    Pao sourcePao = paoDao.getPao(sourceObjectId);
+    Pao destinationPao = paoDao.getPao(destinationObjectId);
+
+    // Step 1: combine the source attributes and destination attributes;
+    //  stop here if there are conflicts
+    List<PolicyConflict> conflicts = mergeAttributes(sourcePao, destinationPao);
+    if (!conflicts.isEmpty()) {
+      return new PolicyUpdateResult(destinationPao, conflicts);
+    }
+
+    // Step 2: merge the sourceObject sources into the destination sources
+    destinationPao.getSourceObjectIds().addAll(sourcePao.getSourceObjectIds());
+
+    // Step 3: do the walk computing the new effective attributes for the destination
+    Walker walker = new Walker(paoDao, destinationPao, destinationObjectId);
+    conflicts = walker.getNewConflicts();
+
+    // If the mode is FAIL_ON_CONFLICT and there are no conflicts, apply the changes
+    if (updateMode == PaoUpdateMode.FAIL_ON_CONFLICT && conflicts.isEmpty()) {
+      walker.applyChanges();
+    }
+
+    return new PolicyUpdateResult(destinationPao, conflicts);
   }
 
   /**
@@ -194,5 +247,42 @@ public class PaoService {
 
     walker.applyChanges();
     return new PolicyUpdateResult(targetPao, conflicts);
+  }
+
+  // This does the first step of clone: merging the
+
+  /**
+   * This method does the first step of clone: merging the source attributes into the destination
+   * attributes. There are never conflicts on the attribute set of objects - only on the effective
+   * attributes. So this merge is much simpler than what we do in the general walking case.
+   *
+   * <p>We return any conflicts found in the process.
+   *
+   * @param sourcePao source of the clone
+   * @param destinationPao destination of the clone
+   * @return conflict list
+   */
+  private List<PolicyConflict> mergeAttributes(Pao sourcePao, Pao destinationPao) {
+    List<PolicyConflict> conflicts = new ArrayList<>();
+    PolicyInputs policyInputs = destinationPao.getAttributes();
+
+    for (PolicyInput input : sourcePao.getAttributes().getInputs().values()) {
+      PolicyInput destinationMatchedPolicy = policyInputs.lookupPolicy(input);
+      // If the policy does not exist in the destination, so we add it
+      if (destinationMatchedPolicy == null) {
+        policyInputs.addInput(input);
+      } else {
+        PolicyInput resultInput = PolicyMutator.combine(destinationMatchedPolicy, input);
+        if (resultInput == null) {
+          // Uh oh, we hit a conflict
+          conflicts.add(new PolicyConflict(destinationPao, sourcePao, input.getPolicyName()));
+        } else {
+          // Replace the policy with the combined policy
+          policyInputs.addInput(resultInput);
+        }
+      }
+    }
+
+    return conflicts;
   }
 }

--- a/service/src/main/java/bio/terra/policy/service/pao/PaoService.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/PaoService.java
@@ -124,6 +124,11 @@ public class PaoService {
    * @param updateMode DRY_RUN or FAIL_ON_CONFLICT
    * @return result of the merge - destination PAO and any policy conflicts
    */
+  @Retryable(interceptor = "transactionRetryInterceptor")
+  @Transactional(
+      isolation = Isolation.SERIALIZABLE,
+      propagation = Propagation.REQUIRED,
+      transactionManager = "tpsTransactionManager")
   public PolicyUpdateResult mergeFromPao(
       UUID sourceObjectId, UUID destinationObjectId, PaoUpdateMode updateMode) {
     if (updateMode == PaoUpdateMode.ENFORCE_CONFLICTS) {

--- a/service/src/main/java/bio/terra/policy/service/pao/model/Pao.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/model/Pao.java
@@ -16,7 +16,6 @@ public class Pao {
   private PolicyInputs attributes;
   private PolicyInputs effectiveAttributes;
   private Set<UUID> sourceObjectIds;
-  private UUID predecessorId;
 
   public Pao(
       UUID objectId,
@@ -24,15 +23,13 @@ public class Pao {
       PaoObjectType objectType,
       PolicyInputs attributes,
       PolicyInputs effectiveAttributes,
-      Set<UUID> sourceObjectIds,
-      UUID predecessorId) {
+      Set<UUID> sourceObjectIds) {
     this.objectId = objectId;
     this.component = component;
     this.objectType = objectType;
     this.attributes = attributes;
     this.effectiveAttributes = effectiveAttributes;
     this.sourceObjectIds = sourceObjectIds;
-    this.predecessorId = predecessorId;
   }
 
   public UUID getObjectId() {
@@ -71,14 +68,6 @@ public class Pao {
     this.sourceObjectIds = sourceObjectIds;
   }
 
-  public UUID getPredecessorId() {
-    return predecessorId;
-  }
-
-  public void setPredecessorId(UUID predecessorId) {
-    this.predecessorId = predecessorId;
-  }
-
   public String toShortString() {
     return String.format("%s:%s (%s)", component, objectType, objectId);
   }
@@ -92,7 +81,6 @@ public class Pao {
         .add("attributes=" + attributes)
         .add("effectiveAttributes=" + effectiveAttributes)
         .add("sourceObjectIds=" + sourceObjectIds)
-        .add("predecessorId=" + predecessorId)
         .toString();
   }
 
@@ -105,7 +93,6 @@ public class Pao {
             dbPao.sources().stream().map(UUID::fromString).collect(Collectors.toSet()))
         .setAttributes(attributeSetMap.get(dbPao.attributeSetId()))
         .setEffectiveAttributes(attributeSetMap.get(dbPao.effectiveSetId()))
-        .setPredecessorId(dbPao.predecessorId())
         .build();
   }
 
@@ -116,7 +103,6 @@ public class Pao {
     private PolicyInputs attributes;
     private PolicyInputs effectiveAttributes;
     private Set<UUID> sourceObjectIds;
-    private UUID predecessorId;
 
     public Builder setObjectId(UUID objectId) {
       this.objectId = objectId;
@@ -148,23 +134,12 @@ public class Pao {
       return this;
     }
 
-    public Builder setPredecessorId(UUID predecessorId) {
-      this.predecessorId = predecessorId;
-      return this;
-    }
-
     public Pao build() {
       if (sourceObjectIds == null) {
         sourceObjectIds = new HashSet<>();
       }
       return new Pao(
-          objectId,
-          component,
-          objectType,
-          attributes,
-          effectiveAttributes,
-          sourceObjectIds,
-          predecessorId);
+          objectId, component, objectType, attributes, effectiveAttributes, sourceObjectIds);
     }
   }
 }

--- a/service/src/main/resources/policydb/changelog.xml
+++ b/service/src/main/resources/policydb/changelog.xml
@@ -6,4 +6,5 @@
   <include file="changesets/20220608_initial.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20220811_attribute_set_index.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20220812_pao_features.yaml" relativeToChangelogFile="true"/>
+  <include file="changesets/20220909_remove_predecessor.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/service/src/main/resources/policydb/changesets/20220909_remove_predecessor.yaml
+++ b/service/src/main/resources/policydb/changesets/20220909_remove_predecessor.yaml
@@ -1,0 +1,8 @@
+databaseChangeLog:
+  - changeSet:
+      id: remove predecessor
+      author: dd
+      changes:
+      - dropColumn:
+          tableName: policy_object
+          columnName: predecessor_id

--- a/testharness/src/test/java/bio/terra/policy/service/pao/PaoMergeTest.java
+++ b/testharness/src/test/java/bio/terra/policy/service/pao/PaoMergeTest.java
@@ -1,0 +1,126 @@
+package bio.terra.policy.service.pao;
+
+import static bio.terra.policy.testutils.PaoTestUtil.DATA1;
+import static bio.terra.policy.testutils.PaoTestUtil.DATA2;
+import static bio.terra.policy.testutils.PaoTestUtil.TEST_DATA_POLICY_X;
+import static bio.terra.policy.testutils.PaoTestUtil.TEST_FLAG_POLICY_A;
+import static bio.terra.policy.testutils.PaoTestUtil.TEST_FLAG_POLICY_B;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import bio.terra.policy.common.model.PolicyInput;
+import bio.terra.policy.service.pao.model.Pao;
+import bio.terra.policy.service.pao.model.PaoUpdateMode;
+import bio.terra.policy.service.policy.model.PolicyUpdateResult;
+import bio.terra.policy.testutils.LibraryTestBase;
+import bio.terra.policy.testutils.PaoTestUtil;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class PaoMergeTest extends LibraryTestBase {
+  private static final Logger logger = LoggerFactory.getLogger(PaoMergeTest.class);
+
+  @Autowired private PaoService paoService;
+
+  @Test
+  void mergeSourceToEmptyDestination() {
+    UUID paoSourceId =
+        PaoTestUtil.makePao(
+            paoService,
+            PaoTestUtil.makeFlagInput(TEST_FLAG_POLICY_A),
+            PaoTestUtil.makeDataInput(TEST_DATA_POLICY_X, DATA1));
+    logger.info("paoSourceId: {}", paoSourceId);
+
+    UUID paoDestinationId = PaoTestUtil.makePao(paoService);
+    logger.info("paoDestinationId: {}", paoDestinationId);
+
+    // merge source to destination - destination should get all source policies
+    PolicyUpdateResult result =
+        paoService.mergeFromPao(paoSourceId, paoDestinationId, PaoUpdateMode.FAIL_ON_CONFLICT);
+    logger.info("merge source to destination result: {}", result);
+    assertTrue(result.conflicts().isEmpty());
+    Pao resultPao = result.computedPao();
+    PaoTestUtil.checkForPolicies(
+        resultPao,
+        PaoTestUtil.makeFlagInput(TEST_FLAG_POLICY_A),
+        PaoTestUtil.makeDataInput(TEST_DATA_POLICY_X, DATA1));
+  }
+
+  @Test
+  void mergeSourceToDestinationNoConflicts() {
+    // PaoA - has flag A and data policy X, data1
+    UUID paoAid =
+        PaoTestUtil.makePao(
+            paoService,
+            PaoTestUtil.makeFlagInput(TEST_FLAG_POLICY_A),
+            PaoTestUtil.makeDataInput(TEST_DATA_POLICY_X, DATA1));
+    logger.info("paoAid: {}", paoAid);
+
+    // PaoB - has flag B and data policy X, data1
+    UUID paoBid =
+        PaoTestUtil.makePao(
+            paoService,
+            PaoTestUtil.makeFlagInput(TEST_FLAG_POLICY_B),
+            PaoTestUtil.makeDataInput(TEST_DATA_POLICY_X, DATA1));
+    logger.info("paoBid: {}", paoBid);
+
+    // merge A into B
+    PolicyUpdateResult result =
+        paoService.mergeFromPao(paoAid, paoBid, PaoUpdateMode.FAIL_ON_CONFLICT);
+    logger.info("merge A to B result: {}", result);
+    assertTrue(result.conflicts().isEmpty());
+    Pao resultPao = result.computedPao();
+    PaoTestUtil.checkForPolicies(
+        resultPao,
+        PaoTestUtil.makeFlagInput(TEST_FLAG_POLICY_A),
+        PaoTestUtil.makeFlagInput(TEST_FLAG_POLICY_B),
+        PaoTestUtil.makeDataInput(TEST_DATA_POLICY_X, DATA1));
+  }
+
+  @Test
+  void mergeSourceToDestinationAttributeConflict() {
+    PolicyInput xData1 = PaoTestUtil.makeDataInput(TEST_DATA_POLICY_X, DATA1);
+    PolicyInput xData2 = PaoTestUtil.makeDataInput(TEST_DATA_POLICY_X, DATA2);
+
+    // PaoA - has flag A and data policy X, data1
+    UUID paoAid =
+        PaoTestUtil.makePao(paoService, PaoTestUtil.makeFlagInput(TEST_FLAG_POLICY_A), xData1);
+    logger.info("paoAid: {}", paoAid);
+
+    // PaoB - has flag B and data policy X, data1
+    UUID paoBid =
+        PaoTestUtil.makePao(paoService, PaoTestUtil.makeFlagInput(TEST_FLAG_POLICY_B), xData2);
+    logger.info("paoBid: {}", paoBid);
+
+    // merge A into B
+    PolicyUpdateResult result =
+        paoService.mergeFromPao(paoAid, paoBid, PaoUpdateMode.FAIL_ON_CONFLICT);
+    logger.info("merge A to B result: {}", result);
+    PaoTestUtil.checkConflictFind(result, paoBid, paoAid, xData1.getPolicyName());
+  }
+
+  @Test
+  void mergeSourceToDestinationSourceConflict() {
+    // Source is empty - gets A as source with xData1
+    // Destination is empty - gets B as source with xData2
+    PolicyInput xData1 = PaoTestUtil.makeDataInput(TEST_DATA_POLICY_X, DATA1);
+    PolicyInput xData2 = PaoTestUtil.makeDataInput(TEST_DATA_POLICY_X, DATA2);
+
+    UUID paoAid = PaoTestUtil.makePao(paoService, xData1);
+    UUID paoBid = PaoTestUtil.makePao(paoService, xData2);
+    UUID paoSourceId = PaoTestUtil.makePao(paoService);
+    UUID paoDestinationId = PaoTestUtil.makePao(paoService);
+
+    paoService.linkSourcePao(paoSourceId, paoAid, PaoUpdateMode.FAIL_ON_CONFLICT);
+    paoService.linkSourcePao(paoDestinationId, paoBid, PaoUpdateMode.FAIL_ON_CONFLICT);
+    PaoTestUtil.checkForPolicies(paoService.getPao(paoSourceId), xData1);
+    PaoTestUtil.checkForPolicies(paoService.getPao(paoDestinationId), xData2);
+
+    // Merging should get a conflict
+    PolicyUpdateResult result =
+        paoService.mergeFromPao(paoSourceId, paoDestinationId, PaoUpdateMode.FAIL_ON_CONFLICT);
+    PaoTestUtil.checkConflictUnknownId(result, paoDestinationId, xData1.getPolicyName());
+  }
+}

--- a/testharness/src/test/java/bio/terra/policy/service/pao/PaoServiceTest.java
+++ b/testharness/src/test/java/bio/terra/policy/service/pao/PaoServiceTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import bio.terra.policy.common.exception.PolicyObjectNotFoundException;
 import bio.terra.policy.common.model.PolicyInput;
 import bio.terra.policy.common.model.PolicyInputs;
-import bio.terra.policy.db.exception.DuplicateObjectException;
 import bio.terra.policy.service.pao.model.Pao;
 import bio.terra.policy.service.pao.model.PaoComponent;
 import bio.terra.policy.service.pao.model.PaoObjectType;
@@ -50,7 +49,6 @@ public class PaoServiceTest extends LibraryTestBase {
     assertEquals(objectId, pao.getObjectId());
     assertEquals(PaoComponent.WSM, pao.getComponent());
     assertEquals(PaoObjectType.WORKSPACE, pao.getObjectType());
-    assertNull(pao.getPredecessorId());
     checkAttributeSet(pao.getAttributes(), groupPolicy, regionPolicy);
     checkAttributeSet(pao.getEffectiveAttributes(), groupPolicy, regionPolicy);
 
@@ -58,49 +56,6 @@ public class PaoServiceTest extends LibraryTestBase {
     paoService.deletePao(objectId);
 
     assertThrows(PolicyObjectNotFoundException.class, () -> paoService.getPao(objectId));
-  }
-
-  @Test
-  void clonePaoTest() throws Exception {
-    var objectId = UUID.randomUUID();
-
-    var groupPolicy =
-        PolicyInput.createFromMap(
-            TERRA, GROUP_CONSTRAINT, Collections.singletonMap(GROUP, DDGROUP));
-    var regionPolicy =
-        PolicyInput.createFromMap(
-            TERRA, REGION_CONSTRAINT, Collections.singletonMap(REGION, US_REGION));
-
-    var inputs = new PolicyInputs();
-    inputs.addInput(groupPolicy);
-    inputs.addInput(regionPolicy);
-
-    // Create a PAO
-    paoService.createPao(objectId, PaoComponent.WSM, PaoObjectType.WORKSPACE, inputs);
-
-    // Clone the PAO
-    final var destinationObjectId = UUID.randomUUID();
-    paoService.clonePao(objectId, destinationObjectId);
-
-    // Retrieve and validate source against clone
-    Pao sourcePao = paoService.getPao(objectId);
-    Pao clonePao = paoService.getPao(destinationObjectId);
-    assertEquals(destinationObjectId, clonePao.getObjectId());
-    assertEquals(objectId, clonePao.getPredecessorId());
-    assertEquals(sourcePao.getComponent(), clonePao.getComponent());
-    assertEquals(sourcePao.getObjectType(), clonePao.getObjectType());
-    checkAttributeSet(clonePao.getAttributes(), groupPolicy, regionPolicy);
-    checkAttributeSet(clonePao.getEffectiveAttributes(), groupPolicy, regionPolicy);
-
-    assertThrows(
-        DuplicateObjectException.class, () -> paoService.clonePao(objectId, destinationObjectId));
-    assertThrows(
-        PolicyObjectNotFoundException.class,
-        () -> paoService.clonePao(UUID.randomUUID(), destinationObjectId));
-
-    // Delete
-    paoService.deletePao(objectId);
-    paoService.deletePao(destinationObjectId);
   }
 
   private void checkAttributeSet(

--- a/testharness/src/test/java/bio/terra/policy/testutils/PaoTestUtil.java
+++ b/testharness/src/test/java/bio/terra/policy/testutils/PaoTestUtil.java
@@ -1,0 +1,104 @@
+package bio.terra.policy.testutils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import bio.terra.policy.common.model.PolicyInput;
+import bio.terra.policy.common.model.PolicyInputs;
+import bio.terra.policy.common.model.PolicyName;
+import bio.terra.policy.service.pao.PaoService;
+import bio.terra.policy.service.pao.graph.model.PolicyConflict;
+import bio.terra.policy.service.pao.model.Pao;
+import bio.terra.policy.service.pao.model.PaoComponent;
+import bio.terra.policy.service.pao.model.PaoObjectType;
+import bio.terra.policy.service.policy.model.PolicyUpdateResult;
+import java.util.Collections;
+import java.util.UUID;
+
+public class PaoTestUtil {
+  public static final String TEST_NAMESPACE = "test_namespace";
+  public static final String TEST_FLAG_POLICY_A = "test_flag_a";
+  public static final String TEST_FLAG_POLICY_B = "test_flag_b";
+  public static final String TEST_DATA_POLICY_X = "test_data_x";
+  public static final String TEST_DATA_POLICY_Y = "test_data_y";
+  public static final String DATA_KEY = "key";
+  public static final String DATA1 = "data1";
+  public static final String DATA2 = "data2";
+
+  public static PolicyInputs makePolicyInputs(PolicyInput... inputList) {
+    var inputs = new PolicyInputs();
+    for (PolicyInput input : inputList) {
+      inputs.addInput(input);
+    }
+    return inputs;
+  }
+
+  public static UUID makePao(PaoService paoService, PolicyInput... inputList) {
+    var inputs = makePolicyInputs(inputList);
+    UUID id = UUID.randomUUID();
+    paoService.createPao(id, PaoComponent.WSM, PaoObjectType.WORKSPACE, inputs);
+    return id;
+  }
+
+  public static PolicyInput makeFlagInput(String name) {
+    return PolicyInput.createFromMap(TEST_NAMESPACE, name, Collections.emptyMap());
+  }
+
+  public static PolicyInput makeDataInput(String name, String data) {
+    return PolicyInput.createFromMap(
+        TEST_NAMESPACE, name, Collections.singletonMap(DATA_KEY, data));
+  }
+
+  public static void checkConflictFind(
+      PolicyUpdateResult result,
+      UUID expectedPaoId,
+      UUID expectedConflictId,
+      PolicyName expectedPolicyName) {
+    PolicyConflict conflict = null;
+    for (var tryConflict : result.conflicts()) {
+      if (tryConflict.pao().getObjectId().equals(expectedPaoId)) {
+        conflict = tryConflict;
+      }
+    }
+    assertNotNull(conflict);
+    assertEquals(expectedConflictId, conflict.conflictPao().getObjectId());
+    assertEquals(expectedPolicyName, conflict.policyName());
+  }
+
+  // Check for when we know what both ids in the conflict will be
+  public static void checkConflict(
+      PolicyUpdateResult result,
+      UUID expectedPaoId,
+      UUID expectedConflictId,
+      PolicyName expectedPolicyName) {
+    checkConflictUnknownId(result, expectedPaoId, expectedPolicyName);
+    assertEquals(expectedConflictId, result.conflicts().get(0).conflictPao().getObjectId());
+  }
+
+  // Check when we do not know what the conflict id will be
+  public static void checkConflictUnknownId(
+      PolicyUpdateResult result, UUID expectedPaoId, PolicyName expectedPolicyName) {
+    assertEquals(1, result.conflicts().size());
+    PolicyConflict conflict = result.conflicts().get(0);
+    assertEquals(expectedPaoId, conflict.pao().getObjectId());
+    assertEquals(expectedPolicyName, conflict.policyName());
+  }
+
+  public static void checkForPolicies(Pao pao, PolicyInput... inputList) {
+    PolicyInputs inputs = pao.getEffectiveAttributes();
+    for (PolicyInput input : inputList) {
+      var foundInput = inputs.lookupPolicy(input);
+      assertNotNull(foundInput);
+      assertEquals(input.getAdditionalData(), foundInput.getAdditionalData());
+    }
+  }
+
+  public static void checkForMissingPolicies(Pao pao, PolicyInput... inputList) {
+    PolicyInputs inputs = pao.getEffectiveAttributes();
+    for (PolicyInput input : inputList) {
+      var foundInput = inputs.lookupPolicy(input);
+      assertNull(foundInput);
+    }
+  }
+}


### PR DESCRIPTION
This PR removes the predecessor field from the database. It implements proper semantics for clone (what was I thinking before??) and renames it to merge. As Doug points out, TPS is not doing a clone. It is providing a way of handling policies that supports workspace clone and might support other things.
