### PR TITLE
[PF-2019] Add replace method and tests

### DIFF
--- a/service/src/main/java/bio/terra/policy/service/pao/PaoService.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/PaoService.java
@@ -106,7 +106,7 @@ public class PaoService {
 
     // We didn't actually change the source list, so we are done
     if (!newSource) {
-      return new PolicyUpdateResult(targetPao, new ArrayList<>());
+      return new PolicyUpdateResult(targetPao, new ArrayList<>(), true);
     }
 
     // Evaluate the change, calculating new effective attribute sets and finding conflicts
@@ -114,11 +114,12 @@ public class PaoService {
     List<PolicyConflict> conflicts = walker.getNewConflicts();
 
     // If the mode is FAIL_ON_CONFLICT and there are no conflicts, apply the changes
-    if (updateMode == PaoUpdateMode.FAIL_ON_CONFLICT && conflicts.isEmpty()) {
+    boolean updateApplied = (updateMode == PaoUpdateMode.FAIL_ON_CONFLICT && conflicts.isEmpty());
+    if (updateApplied) {
       walker.applyChanges();
     }
 
-    return new PolicyUpdateResult(targetPao, conflicts);
+    return new PolicyUpdateResult(targetPao, conflicts, updateApplied);
   }
 
   /**
@@ -147,11 +148,16 @@ public class PaoService {
     Pao sourcePao = paoDao.getPao(sourceObjectId);
     Pao destinationPao = paoDao.getPao(destinationObjectId);
 
+    // If the source and destination are the same PAO, there is nothing to do
+    if (sourceObjectId.equals(destinationObjectId)) {
+      return new PolicyUpdateResult(destinationPao, new ArrayList<>(), true);
+    }
+
     // Step 1: combine the source attributes and destination attributes;
     //  stop here if there are conflicts
     List<PolicyConflict> conflicts = mergeAttributes(sourcePao, destinationPao);
     if (!conflicts.isEmpty()) {
-      return new PolicyUpdateResult(destinationPao, conflicts);
+      return new PolicyUpdateResult(destinationPao, conflicts, false);
     }
 
     // Step 2: merge the sourceObject sources into the destination sources
@@ -162,11 +168,36 @@ public class PaoService {
     conflicts = walker.getNewConflicts();
 
     // If the mode is FAIL_ON_CONFLICT and there are no conflicts, apply the changes
-    if (updateMode == PaoUpdateMode.FAIL_ON_CONFLICT && conflicts.isEmpty()) {
+    boolean updateApplied = (updateMode == PaoUpdateMode.FAIL_ON_CONFLICT && conflicts.isEmpty());
+    if (updateApplied) {
       walker.applyChanges();
     }
 
-    return new PolicyUpdateResult(destinationPao, conflicts);
+    return new PolicyUpdateResult(destinationPao, conflicts, updateApplied);
+  }
+
+  /**
+   * Update the attributes of a Pao and propagate changes.
+   *
+   * @param targetPaoId the object to update
+   * @param replacementAttributes policy inputs to overwrite
+   * @param updateMode how to handle applying the changes
+   */
+  @Retryable(interceptor = "transactionRetryInterceptor")
+  @Transactional(
+      isolation = Isolation.SERIALIZABLE,
+      propagation = Propagation.REQUIRED,
+      transactionManager = "tpsTransactionManager")
+  public PolicyUpdateResult replacePao(
+      UUID targetPaoId, PolicyInputs replacementAttributes, PaoUpdateMode updateMode) {
+    logger.info(
+        "ReplacePao: target {} attributes {} updateMode {}",
+        targetPaoId,
+        replacementAttributes,
+        updateMode);
+
+    Pao targetPao = paoDao.getPao(targetPaoId);
+    return updateAttributesWorker(replacementAttributes, targetPao, updateMode);
   }
 
   /**
@@ -210,7 +241,7 @@ public class PaoService {
       }
     }
 
-    // Now the adds
+    // Now integrate the adds into the attribute set
     for (PolicyInput addPolicy : addAttributes.getInputs().values()) {
       PolicyInput existingPolicy = targetPao.getAttributes().lookupPolicy(addPolicy);
       if (existingPolicy == null) {
@@ -230,7 +261,14 @@ public class PaoService {
       }
     }
 
-    // Set the attributes to the newly computed attributes
+    return updateAttributesWorker(newAttributes, targetPao, updateMode);
+  }
+
+  // Common code to update new attributes to a targetPao
+  // Used by both updatePao and replacePao
+  private PolicyUpdateResult updateAttributesWorker(
+      PolicyInputs newAttributes, Pao targetPao, PaoUpdateMode updateMode) {
+    // Set the target PAO attributes to the newly computed attributes
     targetPao.setAttributes(newAttributes);
 
     // Evaluate the change, calculating new effective attribute sets and finding conflicts
@@ -239,7 +277,7 @@ public class PaoService {
 
     if (updateMode == PaoUpdateMode.DRY_RUN
         || updateMode == PaoUpdateMode.FAIL_ON_CONFLICT && !conflicts.isEmpty()) {
-      return new PolicyUpdateResult(targetPao, conflicts);
+      return new PolicyUpdateResult(targetPao, conflicts, false);
     }
 
     if (updateMode == PaoUpdateMode.ENFORCE_CONFLICTS && !conflicts.isEmpty()) {
@@ -247,7 +285,7 @@ public class PaoService {
       // created any conflicts on the target Pao. We only allow conflicts on dependent
       // Paos.
       for (PolicyConflict conflict : conflicts) {
-        if (conflict.pao().getObjectId().equals(targetPaoId)) {
+        if (conflict.pao().getObjectId().equals(targetPao.getObjectId())) {
           throw new DirectConflictException(
               String.format(
                   "Update of policy %s on %s creates a conflict",
@@ -257,10 +295,8 @@ public class PaoService {
     }
 
     walker.applyChanges();
-    return new PolicyUpdateResult(targetPao, conflicts);
+    return new PolicyUpdateResult(targetPao, conflicts, true);
   }
-
-  // This does the first step of clone: merging the
 
   /**
    * This method does the first step of clone: merging the source attributes into the destination

--- a/service/src/main/java/bio/terra/policy/service/policy/model/PolicyUpdateResult.java
+++ b/service/src/main/java/bio/terra/policy/service/policy/model/PolicyUpdateResult.java
@@ -4,4 +4,5 @@ import bio.terra.policy.service.pao.graph.model.PolicyConflict;
 import bio.terra.policy.service.pao.model.Pao;
 import java.util.List;
 
-public record PolicyUpdateResult(Pao computedPao, List<PolicyConflict> conflicts) {}
+public record PolicyUpdateResult(
+    Pao computedPao, List<PolicyConflict> conflicts, boolean updateApplied) {}

--- a/testharness/src/test/java/bio/terra/policy/service/pao/PaoReplaceTest.java
+++ b/testharness/src/test/java/bio/terra/policy/service/pao/PaoReplaceTest.java
@@ -1,0 +1,102 @@
+package bio.terra.policy.service.pao;
+
+import static bio.terra.policy.testutils.PaoTestUtil.DATA1;
+import static bio.terra.policy.testutils.PaoTestUtil.DATA2;
+import static bio.terra.policy.testutils.PaoTestUtil.TEST_DATA_POLICY_X;
+import static bio.terra.policy.testutils.PaoTestUtil.TEST_FLAG_POLICY_A;
+import static bio.terra.policy.testutils.PaoTestUtil.TEST_FLAG_POLICY_B;
+import static bio.terra.policy.testutils.PaoTestUtil.TEST_NAMESPACE;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import bio.terra.policy.common.model.PolicyName;
+import bio.terra.policy.service.pao.model.Pao;
+import bio.terra.policy.service.pao.model.PaoUpdateMode;
+import bio.terra.policy.service.policy.model.PolicyUpdateResult;
+import bio.terra.policy.testutils.LibraryTestBase;
+import bio.terra.policy.testutils.PaoTestUtil;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class PaoReplaceTest extends LibraryTestBase {
+  private static final Logger logger = LoggerFactory.getLogger(PaoReplaceTest.class);
+
+  @Autowired private PaoService paoService;
+
+  @Test
+  void replaceSimple() {
+    UUID paoId = PaoTestUtil.makePao(paoService);
+    logger.info("paoId: {}", paoId);
+
+    var newAttributes =
+        PaoTestUtil.makePolicyInputs(
+            PaoTestUtil.makeFlagInput(TEST_FLAG_POLICY_A),
+            PaoTestUtil.makeDataInput(TEST_DATA_POLICY_X, DATA1));
+
+    PolicyUpdateResult result =
+        paoService.replacePao(paoId, newAttributes, PaoUpdateMode.FAIL_ON_CONFLICT);
+    logger.info("replace result: {}", result);
+    assertTrue(result.updateApplied());
+    assertTrue(result.conflicts().isEmpty());
+    Pao resultPao = result.computedPao();
+    PaoTestUtil.checkForPolicies(
+        resultPao,
+        PaoTestUtil.makeFlagInput(TEST_FLAG_POLICY_A),
+        PaoTestUtil.makeDataInput(TEST_DATA_POLICY_X, DATA1));
+
+    var moreNewAttributes =
+        PaoTestUtil.makePolicyInputs(
+            PaoTestUtil.makeFlagInput(TEST_FLAG_POLICY_B),
+            PaoTestUtil.makeDataInput(TEST_DATA_POLICY_X, DATA2));
+
+    result = paoService.replacePao(paoId, moreNewAttributes, PaoUpdateMode.FAIL_ON_CONFLICT);
+    logger.info("replace2 result: {}", result);
+    assertTrue(result.updateApplied());
+    assertTrue(result.conflicts().isEmpty());
+    resultPao = result.computedPao();
+    PaoTestUtil.checkForPolicies(
+        resultPao,
+        PaoTestUtil.makeFlagInput(TEST_FLAG_POLICY_B),
+        PaoTestUtil.makeDataInput(TEST_DATA_POLICY_X, DATA2));
+  }
+
+  @Test
+  void replaceConflict() {
+    // PaoA - has flag A and data policy X, data1
+    UUID paoAid =
+        PaoTestUtil.makePao(
+            paoService,
+            PaoTestUtil.makeFlagInput(TEST_FLAG_POLICY_A),
+            PaoTestUtil.makeDataInput(TEST_DATA_POLICY_X, DATA1));
+    logger.info("paoAid: {}", paoAid);
+
+    // PaoB - starts empty
+    UUID paoBid = PaoTestUtil.makePao(paoService);
+    logger.info("paoBid: {}", paoBid);
+
+    // Make A a source for B
+    PolicyUpdateResult result =
+        paoService.linkSourcePao(paoBid, paoAid, PaoUpdateMode.FAIL_ON_CONFLICT);
+    logger.info("merge A to B result: {}", result);
+    assertTrue(result.updateApplied());
+    assertTrue(result.conflicts().isEmpty());
+    Pao resultPao = result.computedPao();
+    PaoTestUtil.checkForPolicies(
+        resultPao,
+        PaoTestUtil.makeFlagInput(TEST_FLAG_POLICY_A),
+        PaoTestUtil.makeDataInput(TEST_DATA_POLICY_X, DATA1));
+
+    // Try a conflicting replace on A
+    var newAttributes =
+        PaoTestUtil.makePolicyInputs(
+            PaoTestUtil.makeFlagInput(TEST_FLAG_POLICY_B),
+            PaoTestUtil.makeDataInput(TEST_DATA_POLICY_X, DATA2));
+    result = paoService.replacePao(paoBid, newAttributes, PaoUpdateMode.FAIL_ON_CONFLICT);
+    assertFalse(result.updateApplied());
+    PaoTestUtil.checkConflict(
+        result, paoBid, paoBid, new PolicyName(TEST_NAMESPACE, TEST_DATA_POLICY_X));
+  }
+}

--- a/testharness/src/test/java/bio/terra/policy/service/pao/PaoUpdateTest.java
+++ b/testharness/src/test/java/bio/terra/policy/service/pao/PaoUpdateTest.java
@@ -8,6 +8,7 @@ import static bio.terra.policy.testutils.PaoTestUtil.TEST_FLAG_POLICY_A;
 import static bio.terra.policy.testutils.PaoTestUtil.TEST_FLAG_POLICY_B;
 import static bio.terra.policy.testutils.PaoTestUtil.TEST_NAMESPACE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -112,6 +113,7 @@ public class PaoUpdateTest extends LibraryTestBase {
     PolicyUpdateResult result =
         paoService.linkSourcePao(paoNone, paoAid, PaoUpdateMode.FAIL_ON_CONFLICT);
     logger.info("Link A to None result: {}", result);
+    assertTrue(result.updateApplied());
     assertTrue(result.conflicts().isEmpty());
     Pao resultPao = result.computedPao();
     assertTrue(resultPao.getSourceObjectIds().contains(paoAid));
@@ -123,6 +125,7 @@ public class PaoUpdateTest extends LibraryTestBase {
     // Link B to None - none should get flag A, flag B, data policy X, data1
     result = paoService.linkSourcePao(paoNone, paoBid, PaoUpdateMode.FAIL_ON_CONFLICT);
     logger.info("Link B to None result: {}", result);
+    assertTrue(result.updateApplied());
     assertTrue(result.conflicts().isEmpty());
     resultPao = result.computedPao();
     assertTrue(resultPao.getSourceObjectIds().contains(paoAid));
@@ -137,6 +140,7 @@ public class PaoUpdateTest extends LibraryTestBase {
     // and data policy Y data 1
     result = paoService.linkSourcePao(paoNone, paoCid, PaoUpdateMode.FAIL_ON_CONFLICT);
     logger.info("Link C to None result: {}", result);
+    assertTrue(result.updateApplied());
     assertTrue(result.conflicts().isEmpty());
     resultPao = result.computedPao();
     assertTrue(resultPao.getSourceObjectIds().contains(paoAid));
@@ -152,6 +156,7 @@ public class PaoUpdateTest extends LibraryTestBase {
     // Link D to None - none should stay in previous state with data policy Y with a conflict
     result = paoService.linkSourcePao(paoNone, paoDid, PaoUpdateMode.FAIL_ON_CONFLICT);
     logger.info("Link D to None result: {}", result);
+    assertFalse(result.updateApplied());
     PaoTestUtil.checkConflict(
         result, paoNone, paoDid, new PolicyName(TEST_NAMESPACE, TEST_DATA_POLICY_Y));
 
@@ -170,6 +175,7 @@ public class PaoUpdateTest extends LibraryTestBase {
     // Link C to D - D should stay the same with data policy Y in conflict
     result = paoService.linkSourcePao(paoDid, paoCid, PaoUpdateMode.FAIL_ON_CONFLICT);
     logger.info("Link C to D result: {}", result);
+    assertFalse(result.updateApplied());
     PaoTestUtil.checkConflict(
         result, paoDid, paoCid, new PolicyName(TEST_NAMESPACE, TEST_DATA_POLICY_Y));
 
@@ -223,6 +229,7 @@ public class PaoUpdateTest extends LibraryTestBase {
     PolicyUpdateResult result =
         paoService.linkSourcePao(paoBid, paoAid, PaoUpdateMode.FAIL_ON_CONFLICT);
     logger.info("Link A to B result: {}", result);
+    assertTrue(result.updateApplied());
     assertTrue(result.conflicts().isEmpty());
     Pao resultPao = result.computedPao();
     assertTrue(resultPao.getSourceObjectIds().contains(paoAid));
@@ -235,6 +242,7 @@ public class PaoUpdateTest extends LibraryTestBase {
     // Link A to C
     result = paoService.linkSourcePao(paoCid, paoAid, PaoUpdateMode.FAIL_ON_CONFLICT);
     logger.info("Link A to C result: {}", result);
+    assertTrue(result.updateApplied());
     assertTrue(result.conflicts().isEmpty());
     resultPao = result.computedPao();
     assertTrue(resultPao.getSourceObjectIds().contains(paoAid));
@@ -247,6 +255,7 @@ public class PaoUpdateTest extends LibraryTestBase {
     // Link B to C
     result = paoService.linkSourcePao(paoCid, paoBid, PaoUpdateMode.FAIL_ON_CONFLICT);
     logger.info("Link B to C result: {}", result);
+    assertTrue(result.updateApplied());
     assertTrue(result.conflicts().isEmpty());
     resultPao = result.computedPao();
     assertTrue(resultPao.getSourceObjectIds().contains(paoAid));
@@ -262,6 +271,7 @@ public class PaoUpdateTest extends LibraryTestBase {
     // and data policy Y data 1
     result = paoService.linkSourcePao(paoNone, paoCid, PaoUpdateMode.FAIL_ON_CONFLICT);
     logger.info("Link C to None result: {}", result);
+    assertTrue(result.updateApplied());
     assertTrue(result.conflicts().isEmpty());
     resultPao = result.computedPao();
     assertTrue(resultPao.getSourceObjectIds().contains(paoCid));
@@ -276,6 +286,7 @@ public class PaoUpdateTest extends LibraryTestBase {
     result = paoService.linkSourcePao(paoNone, paoDid, PaoUpdateMode.FAIL_ON_CONFLICT);
     logger.info("Link D to None result: {}", result);
     // PaoTestUtil.check that we got the right conflict
+    assertFalse(result.updateApplied());
     assertEquals(1, result.conflicts().size());
     PolicyConflict conflict = result.conflicts().get(0);
     assertEquals(paoNone, conflict.pao().getObjectId());
@@ -313,6 +324,7 @@ public class PaoUpdateTest extends LibraryTestBase {
     PolicyUpdateResult result =
         paoService.updatePao(paoId, adds, removes, PaoUpdateMode.FAIL_ON_CONFLICT);
     logger.info("Update 1 removes {} adds {} result {}", removes, adds, result);
+    assertTrue(result.updateApplied());
     assertTrue(result.conflicts().isEmpty());
     Pao resultPao = result.computedPao();
     PaoTestUtil.checkForPolicies(
@@ -325,6 +337,7 @@ public class PaoUpdateTest extends LibraryTestBase {
     // Repeating the operation should get the same result.
     result = paoService.updatePao(paoId, adds, removes, PaoUpdateMode.FAIL_ON_CONFLICT);
     logger.info("Update 2 removes {} adds {} result {}", removes, adds, result);
+    assertTrue(result.updateApplied());
     assertTrue(result.conflicts().isEmpty());
     resultPao = result.computedPao();
     PaoTestUtil.checkForPolicies(
@@ -342,6 +355,7 @@ public class PaoUpdateTest extends LibraryTestBase {
         PaoTestUtil.makePolicyInputs(PaoTestUtil.makeFlagInput(TEST_FLAG_POLICY_A));
     result = paoService.updatePao(paoNone, oneFlag, empty, PaoUpdateMode.FAIL_ON_CONFLICT);
     logger.info("Update 3 removes {} adds {} result {}", removes, adds, result);
+    assertTrue(result.updateApplied());
     assertTrue(result.conflicts().isEmpty());
     resultPao = result.computedPao();
     PaoTestUtil.checkForPolicies(resultPao, PaoTestUtil.makeFlagInput(TEST_FLAG_POLICY_A));
@@ -349,6 +363,7 @@ public class PaoUpdateTest extends LibraryTestBase {
     // Go from one to zero policy
     result = paoService.updatePao(paoNone, empty, oneFlag, PaoUpdateMode.FAIL_ON_CONFLICT);
     logger.info("Update 4 removes {} adds {} result {}", removes, adds, result);
+    assertTrue(result.updateApplied());
     assertTrue(result.conflicts().isEmpty());
     resultPao = result.computedPao();
     assertTrue(resultPao.getEffectiveAttributes().getInputs().isEmpty());
@@ -385,6 +400,7 @@ public class PaoUpdateTest extends LibraryTestBase {
     // Add the flag policy
     PolicyUpdateResult result =
         paoService.updatePao(paoSid, oneFlag, empty, PaoUpdateMode.FAIL_ON_CONFLICT);
+    assertTrue(result.updateApplied());
     assertTrue(result.conflicts().isEmpty());
     PaoTestUtil.checkForPolicies(
         result.computedPao(), PaoTestUtil.makeFlagInput(TEST_FLAG_POLICY_A));
@@ -395,6 +411,7 @@ public class PaoUpdateTest extends LibraryTestBase {
 
     // Remove the flag policy
     result = paoService.updatePao(paoSid, empty, oneFlag, PaoUpdateMode.FAIL_ON_CONFLICT);
+    assertTrue(result.updateApplied());
     assertTrue(result.conflicts().isEmpty());
     assertTrue(result.computedPao().getEffectiveAttributes().getInputs().isEmpty());
 
@@ -430,6 +447,7 @@ public class PaoUpdateTest extends LibraryTestBase {
 
     PolicyUpdateResult result =
         paoService.updatePao(paoS1id, conflictPolicy, empty, PaoUpdateMode.DRY_RUN);
+    assertFalse(result.updateApplied());
     PaoTestUtil.checkConflict(
         result, paoDid, paoS1id, new PolicyName(TEST_NAMESPACE, TEST_DATA_POLICY_X));
     checkD = paoService.getPao(paoDid);
@@ -440,6 +458,7 @@ public class PaoUpdateTest extends LibraryTestBase {
     // Conflict case - FAIL_ON_CONFLICT
     // should have the same result as DRY_RUN, since there is a conflict
     result = paoService.updatePao(paoS1id, conflictPolicy, empty, PaoUpdateMode.FAIL_ON_CONFLICT);
+    assertFalse(result.updateApplied());
     PaoTestUtil.checkConflict(
         result, paoDid, paoS1id, new PolicyName(TEST_NAMESPACE, TEST_DATA_POLICY_X));
     checkD = paoService.getPao(paoDid);
@@ -449,6 +468,7 @@ public class PaoUpdateTest extends LibraryTestBase {
 
     // Conflict case - ENFORCE_CONFLICTS
     result = paoService.updatePao(paoS1id, conflictPolicy, empty, PaoUpdateMode.ENFORCE_CONFLICTS);
+    assertTrue(result.updateApplied());
     PaoTestUtil.checkConflict(
         result, paoDid, paoS1id, new PolicyName(TEST_NAMESPACE, TEST_DATA_POLICY_X));
     checkD = paoService.getPao(paoDid);
@@ -486,6 +506,7 @@ public class PaoUpdateTest extends LibraryTestBase {
     PolicyUpdateResult result =
         paoService.updatePao(paoAid, conflictPolicy, emptyPolicy, PaoUpdateMode.DRY_RUN);
     logger.info("Result: {}", result);
+    assertFalse(result.updateApplied());
     assertEquals(3, result.conflicts().size()); // B, C, and D
     PaoTestUtil.checkConflictFind(result, paoBid, paoAid, xData1.getPolicyName());
     PaoTestUtil.checkConflictFind(result, paoCid, paoBid, xData1.getPolicyName());
@@ -494,6 +515,7 @@ public class PaoUpdateTest extends LibraryTestBase {
     result =
         paoService.updatePao(paoAid, conflictPolicy, emptyPolicy, PaoUpdateMode.FAIL_ON_CONFLICT);
     logger.info("Result: {}", result);
+    assertFalse(result.updateApplied());
     assertEquals(3, result.conflicts().size()); // B, C, and D
     PaoTestUtil.checkConflictFind(result, paoBid, paoAid, xData1.getPolicyName());
     PaoTestUtil.checkConflictFind(result, paoCid, paoBid, xData1.getPolicyName());
@@ -502,6 +524,7 @@ public class PaoUpdateTest extends LibraryTestBase {
     result =
         paoService.updatePao(paoAid, conflictPolicy, emptyPolicy, PaoUpdateMode.ENFORCE_CONFLICTS);
     logger.info("Result: {}", result);
+    assertTrue(result.updateApplied());
     assertEquals(3, result.conflicts().size()); // B, C, and D
     PaoTestUtil.checkConflictFind(result, paoBid, paoAid, xData1.getPolicyName());
     PaoTestUtil.checkConflictFind(result, paoCid, paoBid, xData1.getPolicyName());


### PR DESCRIPTION
The update method we had to support users has lists of policies to add and remove.
That is inconvenient to use as part of `undo()` processing when a flight has made changes to the policy graph.
The PR adds a `replace` method that provides the policy attributes to be replaced wholesale. The implementation shares a lot with `update`, so I factored out the common part.
