### PR TITLE
[PF-2034] Add check for cycles to linkSource

### DIFF
--- a/service/src/main/java/bio/terra/policy/common/exception/IllegalCycleException.java
+++ b/service/src/main/java/bio/terra/policy/common/exception/IllegalCycleException.java
@@ -1,0 +1,9 @@
+package bio.terra.policy.common.exception;
+
+import bio.terra.common.exception.BadRequestException;
+
+public class IllegalCycleException extends BadRequestException {
+  public IllegalCycleException(String message) {
+    super(message);
+  }
+}

--- a/testharness/src/test/java/bio/terra/policy/service/pao/PaoUpdateTest.java
+++ b/testharness/src/test/java/bio/terra/policy/service/pao/PaoUpdateTest.java
@@ -13,6 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.policy.common.exception.DirectConflictException;
+import bio.terra.policy.common.exception.IllegalCycleException;
 import bio.terra.policy.common.exception.InternalTpsErrorException;
 import bio.terra.policy.common.model.PolicyInput;
 import bio.terra.policy.common.model.PolicyInputs;
@@ -290,6 +291,11 @@ public class PaoUpdateTest extends LibraryTestBase {
         PaoTestUtil.makeFlagInput(TEST_FLAG_POLICY_B),
         PaoTestUtil.makeDataInput(TEST_DATA_POLICY_X, DATA1),
         PaoTestUtil.makeDataInput(TEST_DATA_POLICY_Y, DATA1));
+
+    // Link None to A - should fail because it would create a cycle
+    assertThrows(
+        IllegalCycleException.class,
+        () -> paoService.linkSourcePao(paoAid, paoNone, PaoUpdateMode.FAIL_ON_CONFLICT));
   }
 
   @Test


### PR DESCRIPTION
We need to ensure the graph of policy objects is a DAG - it cannot have cycles.
This PR adds a cycle test to the link. I thought this would be a bit of code, but I was able to use recursion in Postgres. It was simple to make a query that returned all descendants. Then I just need to test if the link source is on that list.

Piggy-backed onto an existing test that builds a hierarchy of PAOs.

@yuhuyoyo I thought you might want to look at the SQL for this. Maybe it would make the cycle check for folders simpler?