### PR TITLE
[PF-2168] Switch GCR project; remove unused env

### DIFF
--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -45,8 +45,7 @@ on:
 
 env:
   SERVICE_NAME: ${{ github.event.repository.name }}
-  GOOGLE_PROJECT: terra-kernel-k8s
-  GKE_CLUSTER: terra-kernel-k8s
+  GOOGLE_PROJECT: broad-dsp-gcr-public
 
 jobs:
   bump-check:


### PR DESCRIPTION
TPS is failing to deploy in Broad deployment because of a mismatch between where we are putting the docker image and where the helm file is reading it.