### PR TITLE
PF-2239 Add region ontology

### DIFF
--- a/service/src/main/java/bio/terra/policy/service/region/RegionService.java
+++ b/service/src/main/java/bio/terra/policy/service/region/RegionService.java
@@ -46,6 +46,11 @@ public class RegionService {
     ConstructRegionMapsRecursively(this.ontology);
   }
 
+  public Boolean regionContainsDatacenter(String regionName, String datacenterId) {
+    return regionDatacenterMap.containsKey(regionName)
+        && regionDatacenterMap.get(regionName).contains(datacenterId);
+  }
+
   public Region getRegion(String name) {
     return regionNameMap.containsKey(name) ? regionNameMap.get(name) : null;
   }

--- a/service/src/main/java/bio/terra/policy/service/region/RegionService.java
+++ b/service/src/main/java/bio/terra/policy/service/region/RegionService.java
@@ -6,6 +6,7 @@ import java.io.InputStream;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,8 +18,6 @@ import org.yaml.snakeyaml.constructor.Constructor;
 public class RegionService {
   private static final Logger logger = LoggerFactory.getLogger(RegionService.class);
 
-  private final Region ontology;
-
   private final HashMap<String, HashSet<String>> regionDatacenterMap;
   private final HashMap<String, Region> regionNameMap;
   private final HashMap<String, Datacenter> datacenterNameMap;
@@ -28,8 +27,14 @@ public class RegionService {
     Yaml regionYaml = new Yaml(new Constructor(Region.class));
     InputStream inputStream =
         this.getClass().getClassLoader().getResourceAsStream("static/regions.yml");
-    this.ontology = regionYaml.load(inputStream);
+    Region rootRegion = regionYaml.load(inputStream);
 
+    /**
+     * Snakeyaml can easily transform into java classes like Regions above. However, it can't
+     * naturally load into Java Collections. Datacenters.yml represents an array or List of
+     * Datacenters. Since we want to work with that data type, we first create an object of that
+     * type to indicate to snakeyaml how to load the file.
+     */
     Datacenter[] type = new Datacenter[0];
     Yaml datacenterYaml = new Yaml(new Constructor(type.getClass()));
     inputStream = this.getClass().getClassLoader().getResourceAsStream("static/datacenters.yml");
@@ -43,38 +48,44 @@ public class RegionService {
       this.datacenterNameMap.put(datacenter.getId(), datacenter);
     }
 
-    ConstructRegionMapsRecursively(this.ontology);
+    constructRegionMapsRecursively(rootRegion);
   }
 
-  public Boolean regionContainsDatacenter(String regionName, String datacenterId) {
+  public boolean regionContainsDatacenter(String regionName, String datacenterId) {
     return regionDatacenterMap.containsKey(regionName)
         && regionDatacenterMap.get(regionName).contains(datacenterId);
   }
 
+  @Nullable
   public Region getRegion(String name) {
-    return regionNameMap.containsKey(name) ? regionNameMap.get(name) : null;
+    return regionNameMap.get(name);
   }
 
+  @Nullable
   public Datacenter getDatacenter(String id) {
-    return this.datacenterNameMap.containsKey(id) ? datacenterNameMap.get(id) : null;
+    return datacenterNameMap.get(id);
   }
 
-  private void ConstructRegionMapsRecursively(Region current) {
+  private void constructRegionMapsRecursively(Region current) {
     if (current == null) return;
 
     regionNameMap.put(current.getName(), current);
-
     HashSet<String> currentDatacenters = new HashSet<>();
-
     String[] datacenters = current.getDatacenters();
+
+    // If there are no datacenters defined on the region in the regions.yml file,
+    // snakeyaml will set the value to null rather than populating it with an empty array.
     if (datacenters != null) {
       currentDatacenters.addAll(List.of(datacenters));
     }
 
     Region[] subregions = current.getRegions();
+
+    // Similarly, if there are no subregions defined in the .yml file, then this
+    // field will be null rather than an empty array.
     if (subregions != null) {
       for (Region subregion : current.getRegions()) {
-        ConstructRegionMapsRecursively(subregion);
+        constructRegionMapsRecursively(subregion);
         currentDatacenters.addAll(regionDatacenterMap.get(subregion.getName()));
       }
     }

--- a/service/src/main/java/bio/terra/policy/service/region/RegionService.java
+++ b/service/src/main/java/bio/terra/policy/service/region/RegionService.java
@@ -1,0 +1,79 @@
+package bio.terra.policy.service.region;
+
+import bio.terra.policy.service.region.model.Datacenter;
+import bio.terra.policy.service.region.model.Region;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+
+@Component
+public class RegionService {
+  private static final Logger logger = LoggerFactory.getLogger(RegionService.class);
+
+  private final Region ontology;
+
+  private final HashMap<String, HashSet<String>> regionDatacenterMap;
+  private final HashMap<String, Region> regionNameMap;
+  private final HashMap<String, Datacenter> datacenterNameMap;
+
+  @Autowired
+  public RegionService() {
+    Yaml regionYaml = new Yaml(new Constructor(Region.class));
+    InputStream inputStream =
+        this.getClass().getClassLoader().getResourceAsStream("static/regions.yml");
+    this.ontology = regionYaml.load(inputStream);
+
+    Datacenter[] type = new Datacenter[0];
+    Yaml datacenterYaml = new Yaml(new Constructor(type.getClass()));
+    inputStream = this.getClass().getClassLoader().getResourceAsStream("static/datacenters.yml");
+    Datacenter[] datacenters = datacenterYaml.load(inputStream);
+
+    this.regionDatacenterMap = new HashMap<>();
+    this.regionNameMap = new HashMap<>();
+    this.datacenterNameMap = new HashMap();
+
+    for (Datacenter datacenter : datacenters) {
+      this.datacenterNameMap.put(datacenter.getId(), datacenter);
+    }
+
+    ConstructRegionMapsRecursively(this.ontology);
+  }
+
+  public Region getRegion(String name) {
+    return regionNameMap.containsKey(name) ? regionNameMap.get(name) : null;
+  }
+
+  public Datacenter getDatacenter(String id) {
+    return this.datacenterNameMap.containsKey(id) ? datacenterNameMap.get(id) : null;
+  }
+
+  private void ConstructRegionMapsRecursively(Region current) {
+    if (current == null) return;
+
+    regionNameMap.put(current.getName(), current);
+
+    HashSet<String> currentDatacenters = new HashSet<>();
+
+    String[] datacenters = current.getDatacenters();
+    if (datacenters != null) {
+      currentDatacenters.addAll(List.of(datacenters));
+    }
+
+    Region[] subregions = current.getRegions();
+    if (subregions != null) {
+      for (Region subregion : current.getRegions()) {
+        ConstructRegionMapsRecursively(subregion);
+        currentDatacenters.addAll(regionDatacenterMap.get(subregion.getName()));
+      }
+    }
+
+    regionDatacenterMap.put(current.getName(), currentDatacenters);
+  }
+}

--- a/service/src/main/java/bio/terra/policy/service/region/model/Datacenter.java
+++ b/service/src/main/java/bio/terra/policy/service/region/model/Datacenter.java
@@ -1,0 +1,31 @@
+package bio.terra.policy.service.region.model;
+
+public class Datacenter {
+  private String id;
+  private String description;
+  private String code;
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public String getCode() {
+    return code;
+  }
+
+  public void setCode(String code) {
+    this.code = code;
+  }
+}

--- a/service/src/main/java/bio/terra/policy/service/region/model/Region.java
+++ b/service/src/main/java/bio/terra/policy/service/region/model/Region.java
@@ -1,0 +1,40 @@
+package bio.terra.policy.service.region.model;
+
+public class Region {
+  private String name;
+  private String description;
+  private Region[] regions;
+  private String[] datacenters;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public Region[] getRegions() {
+    return regions;
+  }
+
+  public void setRegions(Region[] regions) {
+    this.regions = regions;
+  }
+
+  public String[] getDatacenters() {
+    return datacenters;
+  }
+
+  public void setDatacenters(String[] datacenters) {
+    this.datacenters = datacenters;
+  }
+}

--- a/service/src/main/resources/static/datacenters.yml
+++ b/service/src/main/resources/static/datacenters.yml
@@ -1,0 +1,191 @@
+---
+# GCP Americas
+- id: gcp.northamerica-northeast1
+  description: Montréal
+  code: northamerica-northeast1
+- id: gcp.northamerica-northeast2
+  description: Toronto
+  code: northamerica-northeast2
+- id: gcp.southamerica-east1
+  description: São Paulo
+  code: southamerica-east1
+- id: gcp.southamerica-west1
+  description: Santiago
+  code: southamerica-west1
+- id: gcp.us-central1
+  description: Iowa
+  code: us-central1
+- id: gcp.us-east1
+  description: South Carolina
+  code: us-east1
+- id: gcp.us-east4
+  description: Northern Virginia
+  code: us-east4
+- id: gcp.us-west1
+  description: Oregon
+  code: us-west1
+- id: gcp.us-west2
+  description: Los Angeles
+  code: us-west2
+- id: gcp.us-west3
+  description: Salt Lake City
+  code: us-west3
+- id: gcp.us-west4
+  description: Las Vegas
+  code: us-west4
+
+# GCP Asia Pacific
+- id: gcp.asia-south2
+  description: Delhi
+  code: asia-south2
+- id: gcp.asia-east2
+  description: Hong Kong
+  code: asia-east2
+- id: gcp.asia-southeast2
+  description: Jakarta
+  code: asia-southeast2
+- id: gcp.australia-southeast2
+  description: Melbourne
+  code: australia-southeast2
+- id: gcp.asia-south1
+  description: Mumbai
+  code: asia-south2
+- id: gcp.northeast2
+  description: Osaka
+  code: asia-northeast2
+- id: gcp.asia-northeast3
+  description: Seoul
+  code: asia-northeast3
+- id: gcp.asia-southeast1
+  description: Singapore
+  code: asia-southeast1
+- id: gcp.australia-southeast1
+  description: Sydney
+  code: australia-southeast1
+- id: gcp.asia-east1
+  description: Taiwan
+  code: asia-east1
+- id: gcp.asia-northeast1
+  description: Tokyo
+  code: asia-northeast1
+
+# GCP Europe
+- id: gcp.europe-west1
+  description: Belgium
+  code: europe-west1
+- id: gcp.europe-north1
+  description: Finland
+  code: gcp.europe-north1
+- id: gcp.europe-west3
+  description: Frankfurt
+  code: europe-west3
+- id: gcp.europe-west2
+  description: London
+  code: europe-west2
+- id: gcp.europe-southwest1
+  description: Madrid
+  code: europe-southwest1
+- id: gcp.europe-west8
+  description: Milan
+  code: europe-west8
+- id: gcp.europe-west4
+  description: Netherlands
+  code: europe-west4
+- id: gcp.europe-west9
+  description: Paris
+  code: europe-west4
+- id: gcp.europe-central2
+  description: Warsaw
+  code: europe-central2
+- id: gcp.europe-west6
+  description: Zürich
+  code: europe-west6
+
+# GCP Multi Region
+- id: gcp.EU
+  description: European Union Multi-Region
+  code: EU
+- id: gcp.US
+  description: United States Multi-Region
+  code: US
+
+# Azure Americas
+- id: azure.centralus
+  description: Iowa
+  code: centralus
+- id: azure.eastus2
+  description: Virginia
+  code: eastus2
+- id: azure.northcentralus
+  description: Illinois
+  code: northcentralus
+- id: azure.southcentralus
+  description: Texas
+  code: southcentralus
+- id: azure.westus2
+  description: Washington
+  code: westus2
+- id: azure.westus3
+  description: Arizona
+  code: westus3
+- id: azure.canadacentral
+  description: Toronto
+  code: canadacentral
+- id: azure.canadaeast
+  description: Quebec City
+  code: canadaeast
+- id: azure.brazilsouth
+  description: São Paulo
+  code: brazilsouth
+
+# Azure Asia Pacific
+- id: azure.eastasia
+  description: Hong Kong
+  code: eastasia
+- id: azure.southeastasia
+  description: Singapore
+  code: southeastasia
+- id: azure.centralindia
+  description: Pune
+  code: centralindia
+- id: azure.southindia
+  description: Chennai
+  code: southindia
+- id: azure.japaneast
+  description: Tokyo
+  code: japaneast
+- id: azure.japanwest
+  description: Osaka
+  code: japanwest
+- id: azure.koreacentral
+  description: Seoul
+  code: koreacentral
+- id: azure.australiaeast
+  description: New South Wales
+  code: australiaeast
+
+# Azure Europe
+- id: azure.swedencentral
+  description: Gävle
+  code: swedencentral
+- id: azure.germanywestcentral
+  description: Frankfurt
+  code: germanywestcentral
+- id: azure.northeurope
+  description: Ireland
+  code: northeurope
+- id: azure.uksouth
+  description: London
+  code: uksouth
+- id: azure.westeurope
+  description: Netherlands
+  code: westeurope
+- id: azure.norwayeast
+  description: Oslo
+  code: norwayeast
+- id: azure.francecentral
+  description: Paris
+  code: francecentral
+- id: azure.switzerlandnorth
+  description: Zürich
+  code: switzerlandnorth

--- a/service/src/main/resources/static/regions.yml
+++ b/service/src/main/resources/static/regions.yml
@@ -1,0 +1,120 @@
+---
+name: global
+description: Global Region
+regions:
+  - name: europe
+    description: Europe
+    regions:
+      - name: uk
+        description: United Kingdom
+        datacenters:
+          - gcp.europe-west2
+          - azure.uksouth
+      - name: finland
+        description: Finland
+        datacenters:
+          - gcp.europe-north1
+      - name: germany
+        description: Germany
+        datacenters:
+          - gcp.europe-west3
+          - azure.germanywestcentral
+      - name: multiregion-eu
+        description: Multi-Region EU
+        datacenters:
+          - gcp.eu
+    datacenters:
+      - gcp.europe-west1
+      - gcp.europe-southwest1
+      - gcp.europe-west8
+      - gcp.europe-west4
+      - gcp.europe-central2
+      - gcp.europe-west6
+      - azure.swedencentral
+      - azure.northeurope
+      - azure.westeurope
+      - azure.norwayeast
+      - azure.francecentral
+      - azure.switzerlandnorth
+  - name: americas
+    description: North and South America
+    regions:
+      - name: usa
+        description: United States of America
+        regions:
+          - name: usa-central
+            description: Central US
+            datacenters:
+              - gcp.us-central1
+              - azure.centralus
+              - azure.northcentralus
+              - azure.southcentralus
+          - name: usa-east
+            description: Eastern US
+            datacenters:
+              - gcp.us-east1
+              - gcp.us-east4
+              - azure.eastus2
+          - name: usa-west
+            description: Western US
+            datacenters:
+              - gcp.us-west1
+              - gcp.us-west2
+              - gcp.us-west3
+              - gcp.us-west4
+              - azure.westus2
+              - azure.westus3
+          - name: multiregion-us
+            description: Multi-region US
+            datacenters:
+              - gcp.us
+      - name: canada
+        description: Canada
+        datacenters:
+          - gcp.northamerica-northeast1
+          - gcp.northamerica-northeast2
+          - azure.canadacentral
+          - azure.canadaeast
+      - name: brazil
+        description: Brazil
+        datacenters:
+          - gcp.southamerica-east1
+          - azure.brazilsouth
+      - name: chile
+        description: Chile
+        datacenters:
+          - gcp.gcp.southamerica-west1
+  - name: asiapacific
+    description: Asia and Pacific
+    regions:
+      - name: japan
+        description: Japan
+        datacenters:
+          - gcp.asia-northeast1
+          - gcp.asia-northeast2
+          - azure.japaneast
+          - azure.japanwest
+    datacenters:
+      - gcp.asia-south2
+      - gcp.asia-east2
+      - gcp.asia-southeast2
+      - gcp.australia-southeast2
+      - gcp.asia-south1
+      - gcp.asia-northeast3
+      - gcp.asia-southeast1
+      - gcp.australia-southeast1
+      - gcp.asia-east1
+      - azure.eastasia
+      - azure.southeastasia
+      - azure.centralindia
+      - azure.southindia
+      - azure.koreacentral
+      - azure.australiaeast
+  - name: specific-datacenter
+    description: Container for each individual datacenter
+    regions:
+    # TODO: Add all the others here.
+      - name: gcp.europe-west3
+        description: Europe West 3
+        datacenters:
+          - gcp.europe-west3

--- a/service/src/test/java/bio/terra/policy/service/region/RegionServiceTest.java
+++ b/service/src/test/java/bio/terra/policy/service/region/RegionServiceTest.java
@@ -1,8 +1,10 @@
 package bio.terra.policy.service.region;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.policy.service.region.model.Datacenter;
 import bio.terra.policy.service.region.model.Region;
@@ -42,5 +44,20 @@ public class RegionServiceTest extends TestUnitBase {
     String searchName = "invalid";
     Datacenter result = regionService.getDatacenter(searchName);
     assertNull(result);
+  }
+
+  @Test
+  void regionContainsDatacenterFromItself() {
+    assertTrue(regionService.regionContainsDatacenter("europe", "gcp.europe-west1"));
+  }
+
+  @Test
+  void regionContainsDatacenterFromSubRegion() {
+    assertTrue(regionService.regionContainsDatacenter("usa", "azure.centralus"));
+  }
+
+  @Test
+  void regionContainsDatacenterNegative() {
+    assertFalse(regionService.regionContainsDatacenter("usa", "gcp.europe-west1"));
   }
 }

--- a/service/src/test/java/bio/terra/policy/service/region/RegionServiceTest.java
+++ b/service/src/test/java/bio/terra/policy/service/region/RegionServiceTest.java
@@ -1,0 +1,46 @@
+package bio.terra.policy.service.region;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import bio.terra.policy.service.region.model.Datacenter;
+import bio.terra.policy.service.region.model.Region;
+import bio.terra.policy.testutils.TestUnitBase;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class RegionServiceTest extends TestUnitBase {
+
+  @Autowired private RegionService regionService;
+
+  @Test
+  void getRegion() {
+    String searchRegion = "gcp.europe-west3";
+    Region result = regionService.getRegion(searchRegion);
+    assertNotNull(result);
+    assertEquals(searchRegion, result.getName());
+  }
+
+  @Test
+  void getRegionInvalidRegionReturnsNull() {
+    String searchRegion = "invalid";
+    Region result = regionService.getRegion(searchRegion);
+    assertNull(result);
+  }
+
+  @Test
+  void getDatacenter() {
+    String searchName = "gcp.us-central1";
+    Datacenter result = regionService.getDatacenter(searchName);
+    assertNotNull(result);
+    assertEquals(searchName, result.getId());
+  }
+
+  @Test
+  void getDatacenterInvalidIdReturnsNull() {
+    String searchName = "invalid";
+    Datacenter result = regionService.getDatacenter(searchName);
+    assertNull(result);
+  }
+}


### PR DESCRIPTION
Regions and datacenters are added as .yml files. Eventually we may want to persist these into the db.
This includes the methods for determining if a datacenter is inside of a region, which would enable what's needed for PF-2240.