### PR TITLE
PF-2303: API to list-valid regions given PolicyInputs

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -306,6 +306,34 @@ paths:
           $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/ServerError'
+  /api/policy/v1alpha1/region/list-valid:
+    parameters:
+    - $ref: '#/components/parameters/Platform'
+    post:
+      summary: Retrieve the list of datacenters allowed for the policy inputs
+      operationId: listValidByPolicyInput
+      tags: [Tps]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TpsPolicyInputs'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TpsDatacenterList'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
 
 components:
   parameters:

--- a/service/src/main/java/bio/terra/policy/service/region/RegionService.java
+++ b/service/src/main/java/bio/terra/policy/service/region/RegionService.java
@@ -79,17 +79,8 @@ public class RegionService {
     return regionNameMap.get(name);
   }
 
-  /**
-   * Read through the PAO and its region constraints to determine which data centers should be
-   * available.
-   *
-   * @param pao The PAO to scan.
-   * @param platform The platform for the PAO - IE: gcp | azure
-   * @return the set of datacenter codes allowed by the PAO. Codes do not include the platform
-   *     prefix.
-   */
-  public HashSet<String> getPaoDatacenterCodes(Pao pao, String platform) {
-    List<String> regionNames = extractPolicyRegions(pao);
+  public HashSet<String> getPolicyInputDataCenterCodes(PolicyInputs inputs, String platform) {
+    List<String> regionNames = extractPolicyInputRegions(inputs);
     HashSet<String> result = new HashSet<>();
 
     if (regionNames.isEmpty()) {
@@ -116,7 +107,7 @@ public class RegionService {
   }
 
   public boolean isDatacenterAllowedByPao(Pao pao, String datacenter, String platform) {
-    List<String> regionNames = extractPolicyRegions(pao);
+    List<String> regionNames = extractPolicyInputRegions(pao.getEffectiveAttributes());
 
     if (regionNames.isEmpty()) {
       // pao doesn't have a region constraint
@@ -168,12 +159,11 @@ public class RegionService {
     regionSubregionMap.put(current.getName(), currentSubregions);
   }
 
-  private List<String> extractPolicyRegions(Pao pao) {
+  private List<String> extractPolicyInputRegions(PolicyInputs policyInputs) {
     List<String> result = new ArrayList<>();
-    PolicyInputs effectiveAttributes = pao.getEffectiveAttributes();
 
-    if (effectiveAttributes != null && effectiveAttributes.getInputs() != null) {
-      Map<String, PolicyInput> inputs = effectiveAttributes.getInputs();
+    if (policyInputs != null && policyInputs.getInputs() != null) {
+      Map<String, PolicyInput> inputs = policyInputs.getInputs();
 
       for (var key : inputs.keySet()) {
         if (key.equals(TERRA_REGION_CONSTRAINT)) {

--- a/service/src/test/java/bio/terra/policy/service/region/RegionServiceTest.java
+++ b/service/src/test/java/bio/terra/policy/service/region/RegionServiceTest.java
@@ -77,7 +77,8 @@ public class RegionServiceTest extends TestUnitBase {
     var targetRegion = GCP_PLATFORM + "." + targetDatacenter;
 
     var pao = createPao(targetRegion);
-    var datacenters = regionService.getPaoDatacenterCodes(pao, GCP_PLATFORM);
+    var datacenters =
+        regionService.getPolicyInputDataCenterCodes(pao.getEffectiveAttributes(), GCP_PLATFORM);
 
     assertTrue(datacenters.contains(targetDatacenter));
   }
@@ -88,7 +89,8 @@ public class RegionServiceTest extends TestUnitBase {
     var childDatacenter = "us-central1";
 
     var pao = createPao(region);
-    var datacenters = regionService.getPaoDatacenterCodes(pao, GCP_PLATFORM);
+    var datacenters =
+        regionService.getPolicyInputDataCenterCodes(pao.getEffectiveAttributes(), GCP_PLATFORM);
 
     assertTrue(datacenters.size() > 1);
     assertTrue(datacenters.contains(childDatacenter));
@@ -100,7 +102,8 @@ public class RegionServiceTest extends TestUnitBase {
     var childDatacenterCode = "europe-west3";
 
     var pao = createPao(region);
-    var datacenters = regionService.getPaoDatacenterCodes(pao, GCP_PLATFORM);
+    var datacenters =
+        regionService.getPolicyInputDataCenterCodes(pao.getEffectiveAttributes(), GCP_PLATFORM);
 
     assertTrue(datacenters.size() > 1);
     assertFalse(datacenters.contains(childDatacenterCode));
@@ -113,7 +116,8 @@ public class RegionServiceTest extends TestUnitBase {
     paoService.createPao(objectId, PaoComponent.WSM, PaoObjectType.WORKSPACE, new PolicyInputs());
     var pao = paoService.getPao(objectId);
 
-    var datacenters = regionService.getPaoDatacenterCodes(pao, GCP_PLATFORM);
+    var datacenters =
+        regionService.getPolicyInputDataCenterCodes(pao.getEffectiveAttributes(), GCP_PLATFORM);
 
     // Pao should be allowed all datacenters
     assertTrue(datacenters.size() > 10);


### PR DESCRIPTION
This is for the DRY_RUN scenario where we aren't storing a PAO and so we can't use it to look up policies and regions. In this case, all we have is the policy inputs but we can use those to check for region constraints and build the list of valid data centers from it.