### PR TITLE
PF-2292: API for exploring the region ontology

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -280,6 +280,58 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
+  /api/policy/v1alpha1/region:
+    parameters:
+      - $ref: '#/components/parameters/Platform'
+      - $ref: '#/components/parameters/RegionName'
+    get:
+      summary: Query to explore the region ontology. Find more information about what is inside of a given region
+      operationId: getRegionInfo
+      tags: [Tps]
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TpsRegion'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
+  /api/policy/v1alpha1/region/datacenters:
+    parameters:
+    - $ref: '#/components/parameters/Platform'
+    - $ref: '#/components/parameters/RegionName'
+    get:
+      summary: Get the list of all data centers inside of a region.
+      operationId: getRegionDatacenters
+      tags: [Tps]
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TpsDatacenterList'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
   /api/policy/v1alpha1/region/{objectId}/evaluate:
     parameters:
       - $ref: '#/components/parameters/TpsObjectId'
@@ -328,6 +380,7 @@ paths:
           $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/ServerError'
+
   /api/policy/v1alpha1/region/list-valid:
     parameters:
     - $ref: '#/components/parameters/Platform'
@@ -375,6 +428,14 @@ components:
       schema:
         type: string
         enum: ["gcp", "azure"]
+
+    RegionName:
+      name: region
+      in: query
+      description: The region to query
+      required: false
+      schema:
+        type: string
 
     TpsObjectId:
       name: objectId
@@ -711,6 +772,24 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TpsPaoConflict'
+
+    TpsRegion:
+      description: Region object description.
+      type: object
+      properties:
+          name:
+            description: The region name
+            type: string
+          description:
+            description: The region description
+            type: string
+          regions:
+            description: Subregions contained within this region.
+            type: array
+            items:
+              $ref: '#/components/schemas/TpsRegion'
+          datacenters:
+            $ref: '#/components/schemas/TpsDatacenterList'
 
     TpsUpdateMode:
       type: string

--- a/service/src/main/java/bio/terra/policy/app/controller/ConversionUtils.java
+++ b/service/src/main/java/bio/terra/policy/app/controller/ConversionUtils.java
@@ -4,6 +4,7 @@ import bio.terra.policy.common.exception.InvalidInputException;
 import bio.terra.policy.common.model.PolicyInput;
 import bio.terra.policy.common.model.PolicyInputs;
 import bio.terra.policy.common.model.PolicyName;
+import bio.terra.policy.generated.model.ApiTpsDatacenterList;
 import bio.terra.policy.generated.model.ApiTpsPaoConflict;
 import bio.terra.policy.generated.model.ApiTpsPaoDescription;
 import bio.terra.policy.generated.model.ApiTpsPaoGetResult;
@@ -11,11 +12,14 @@ import bio.terra.policy.generated.model.ApiTpsPaoUpdateResult;
 import bio.terra.policy.generated.model.ApiTpsPolicyInput;
 import bio.terra.policy.generated.model.ApiTpsPolicyInputs;
 import bio.terra.policy.generated.model.ApiTpsPolicyPair;
+import bio.terra.policy.generated.model.ApiTpsRegion;
 import bio.terra.policy.service.pao.graph.model.PolicyConflict;
 import bio.terra.policy.service.pao.model.Pao;
 import bio.terra.policy.service.policy.model.PolicyUpdateResult;
+import bio.terra.policy.service.region.model.Region;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -91,6 +95,25 @@ public class ConversionUtils {
         .effectiveAttributes(policyInputsToApi(pao.getEffectiveAttributes()))
         .sourcesObjectIds(pao.getSourceObjectIds().stream().toList())
         .deleted((pao.getDeleted()));
+  }
+
+  static ApiTpsRegion regionToApi(Region region) {
+    ApiTpsRegion apiRegion =
+        new ApiTpsRegion().name(region.getName()).description(region.getDescription());
+
+    ApiTpsDatacenterList datacenterList = new ApiTpsDatacenterList();
+    if (region.getDatacenters() != null) {
+      datacenterList.addAll(Arrays.stream(region.getDatacenters()).toList());
+    }
+    apiRegion.setDatacenters(datacenterList);
+
+    if (region.getRegions() != null) {
+      for (Region subregion : region.getRegions()) {
+        apiRegion.addRegionsItem(regionToApi(subregion));
+      }
+    }
+
+    return apiRegion;
   }
 
   static ApiTpsPaoUpdateResult updateResultToApi(PolicyUpdateResult result) {

--- a/service/src/main/java/bio/terra/policy/app/controller/TpsApiController.java
+++ b/service/src/main/java/bio/terra/policy/app/controller/TpsApiController.java
@@ -14,6 +14,7 @@ import bio.terra.policy.generated.model.ApiTpsPaoUpdateResult;
 import bio.terra.policy.generated.model.ApiTpsPolicyExplainSource;
 import bio.terra.policy.generated.model.ApiTpsPolicyExplanation;
 import bio.terra.policy.generated.model.ApiTpsPolicyInputs;
+import bio.terra.policy.generated.model.ApiTpsRegion;
 import bio.terra.policy.service.pao.PaoService;
 import bio.terra.policy.service.pao.graph.model.ExplainGraph;
 import bio.terra.policy.service.pao.graph.model.ExplainGraphNode;
@@ -23,6 +24,7 @@ import bio.terra.policy.service.pao.model.PaoObjectType;
 import bio.terra.policy.service.pao.model.PaoUpdateMode;
 import bio.terra.policy.service.policy.model.PolicyUpdateResult;
 import bio.terra.policy.service.region.RegionService;
+import bio.terra.policy.service.region.model.Region;
 import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
@@ -105,6 +107,30 @@ public class TpsApiController implements TpsApi {
   public ResponseEntity<ApiTpsPaoGetResult> getPao(UUID objectId) {
     Pao pao = paoService.getPao(objectId);
     ApiTpsPaoGetResult result = ConversionUtils.paoToApi(pao);
+    return new ResponseEntity<>(result, HttpStatus.OK);
+  }
+
+  @Override
+  public ResponseEntity<ApiTpsDatacenterList> getRegionDatacenters(String platform, String region) {
+    ApiTpsDatacenterList result = new ApiTpsDatacenterList();
+
+    var list = regionService.getDataCentersForRegion(region, platform);
+
+    if (list == null) {
+      return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+    }
+
+    result.addAll(list);
+    return new ResponseEntity<>(result, HttpStatus.OK);
+  }
+
+  @Override
+  public ResponseEntity<ApiTpsRegion> getRegionInfo(String platform, String regionName) {
+    Region region = regionService.getOntology(regionName, platform);
+    if (region == null) {
+      return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+    }
+    ApiTpsRegion result = ConversionUtils.regionToApi(region);
     return new ResponseEntity<>(result, HttpStatus.OK);
   }
 

--- a/service/src/test/java/bio/terra/policy/service/region/RegionServiceTest.java
+++ b/service/src/test/java/bio/terra/policy/service/region/RegionServiceTest.java
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 public class RegionServiceTest extends TestUnitBase {
   private static final String GCP_PLATFORM = "gcp";
+  private static final String AZURE_PLATFORM = "azure";
 
   @Autowired private RegionService regionService;
   @Autowired private PaoService paoService;
@@ -69,6 +70,41 @@ public class RegionServiceTest extends TestUnitBase {
   @Test
   void regionContainsDatacenterNegative() {
     assertFalse(regionService.regionContainsDatacenter("usa", "gcp.europe-west1"));
+  }
+
+  @Test
+  void getDatacentersForRegionsInvalidRegion() {
+    var result = regionService.getDataCentersForRegion("invalid", GCP_PLATFORM);
+    assertEquals(0, result.size());
+  }
+
+  @Test
+  void getDatacentersForRegionsAzureFilter() {
+    var result = regionService.getDataCentersForRegion("global", AZURE_PLATFORM);
+    assertEquals(0, result.size());
+  }
+
+  @Test
+  void getDatacentersForRegionsGlobal() {
+    var result = regionService.getDataCentersForRegion("global", GCP_PLATFORM);
+    assertTrue(result.size() > 10);
+  }
+
+  @Test
+  void getOntologyInvalidRegionName() {
+    assertNull(regionService.getOntology("invalid", GCP_PLATFORM));
+  }
+
+  @Test
+  void getOntologyFiltersByAzurePlatform() {
+    var result = regionService.getOntology("gcp.us-central1", AZURE_PLATFORM);
+    assertEquals(0, result.getDatacenters().length);
+  }
+
+  @Test
+  void getOntologyFiltersByGcpPlatform() {
+    var result = regionService.getOntology("gcp.us-central1", GCP_PLATFORM);
+    assertEquals(1, result.getDatacenters().length);
   }
 
   @Test


### PR DESCRIPTION
Adds 2 APIs -
GET /regions which will let you query by region name to find subregions.
GET /regions/datacenters which gets a flattened list of data centers available in a region and subregions.