### PR TITLE
Bug fix for calling region endpoint with no regionName

### DIFF
--- a/service/src/main/java/bio/terra/policy/service/region/RegionService.java
+++ b/service/src/main/java/bio/terra/policy/service/region/RegionService.java
@@ -5,6 +5,7 @@ import bio.terra.policy.common.model.PolicyInputs;
 import bio.terra.policy.service.pao.model.Pao;
 import bio.terra.policy.service.region.model.Datacenter;
 import bio.terra.policy.service.region.model.Region;
+import com.google.common.base.Strings;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -76,7 +77,7 @@ public class RegionService {
    */
   @Nullable
   public HashSet<String> getDataCentersForRegion(String regionName, String platform) {
-    String queryRegion = (regionName == null || regionName.isEmpty()) ? GLOBAL_REGION : regionName;
+    String queryRegion = Strings.isNullOrEmpty(regionName) ? GLOBAL_REGION : regionName;
     HashSet<String> result = new HashSet<>();
     HashSet<String> regionDataCenters = regionDatacenterMap.get(queryRegion);
     result.addAll(filterDataCentersByPlatform(regionDataCenters, platform));
@@ -89,7 +90,7 @@ public class RegionService {
    */
   @Nullable
   public Region getOntology(String regionName, String platform) {
-    String queryRegion = (regionName == null || regionName.isEmpty()) ? GLOBAL_REGION : regionName;
+    String queryRegion = Strings.isNullOrEmpty(regionName) ? GLOBAL_REGION : regionName;
     Region mappedRegion = regionNameMap.get(queryRegion);
 
     if (mappedRegion == null) {

--- a/service/src/main/java/bio/terra/policy/service/region/RegionService.java
+++ b/service/src/main/java/bio/terra/policy/service/region/RegionService.java
@@ -76,8 +76,9 @@ public class RegionService {
    */
   @Nullable
   public HashSet<String> getDataCentersForRegion(String regionName, String platform) {
+    String queryRegion = (regionName == null || regionName.isEmpty()) ? GLOBAL_REGION : regionName;
     HashSet<String> result = new HashSet<>();
-    HashSet<String> regionDataCenters = regionDatacenterMap.get(regionName);
+    HashSet<String> regionDataCenters = regionDatacenterMap.get(queryRegion);
     result.addAll(filterDataCentersByPlatform(regionDataCenters, platform));
     return result;
   }

--- a/service/src/main/java/bio/terra/policy/service/region/RegionService.java
+++ b/service/src/main/java/bio/terra/policy/service/region/RegionService.java
@@ -88,7 +88,8 @@ public class RegionService {
    */
   @Nullable
   public Region getOntology(String regionName, String platform) {
-    Region mappedRegion = regionNameMap.get(regionName);
+    String queryRegion = (regionName == null || regionName.isEmpty()) ? GLOBAL_REGION : regionName;
+    Region mappedRegion = regionNameMap.get(queryRegion);
 
     if (mappedRegion == null) {
       return null;
@@ -98,8 +99,14 @@ public class RegionService {
     result.setName(mappedRegion.getName());
     result.setDescription(mappedRegion.getDescription());
 
+    String[] datacenters = mappedRegion.getDatacenters();
+
+    if (datacenters == null) {
+      datacenters = new String[0];
+    }
+
     List<String> filteredDatacenters =
-        filterDataCentersByPlatform(Arrays.asList(mappedRegion.getDatacenters()), platform);
+        filterDataCentersByPlatform(Arrays.asList(datacenters), platform);
 
     result.setDatacenters(filteredDatacenters.toArray(new String[0]));
 

--- a/service/src/test/java/bio/terra/policy/service/region/RegionServiceTest.java
+++ b/service/src/test/java/bio/terra/policy/service/region/RegionServiceTest.java
@@ -91,6 +91,31 @@ public class RegionServiceTest extends TestUnitBase {
   }
 
   @Test
+  void getOntologyGlobalRegion() {
+    var result = regionService.getOntology("global", GCP_PLATFORM);
+    assertNotNull(result);
+  }
+
+  @Test
+  void getOntologyEmptyRegion() {
+    var result = regionService.getOntology("", GCP_PLATFORM);
+    assertNotNull(result);
+  }
+
+  @Test
+  /** As an optional query param for the primary API caller, the name might be null. * */
+  void getOntologyNullRegion() {
+    var result = regionService.getOntology(null, GCP_PLATFORM);
+    assertNotNull(result);
+  }
+
+  @Test
+  void getOntologyChildRegion() {
+    var result = regionService.getOntology("usa", GCP_PLATFORM);
+    assertNotNull(result);
+  }
+
+  @Test
   void getOntologyInvalidRegionName() {
     assertNull(regionService.getOntology("invalid", GCP_PLATFORM));
   }

--- a/service/src/test/java/bio/terra/policy/service/region/RegionServiceTest.java
+++ b/service/src/test/java/bio/terra/policy/service/region/RegionServiceTest.java
@@ -79,6 +79,20 @@ public class RegionServiceTest extends TestUnitBase {
   }
 
   @Test
+  void getDatacentersForRegionsEmptyRegion() {
+    var result = regionService.getDataCentersForRegion("", GCP_PLATFORM);
+    assertNotNull(result);
+    assertTrue(result.size() > 1);
+  }
+
+  @Test
+  void getDatacentersForRegionsNullRegion() {
+    var result = regionService.getDataCentersForRegion(null, GCP_PLATFORM);
+    assertNotNull(result);
+    assertTrue(result.size() > 1);
+  }
+
+  @Test
   void getDatacentersForRegionsAzureFilter() {
     var result = regionService.getDataCentersForRegion("global", AZURE_PLATFORM);
     assertEquals(0, result.size());

--- a/service/src/test/java/bio/terra/policy/service/region/RegionServiceTest.java
+++ b/service/src/test/java/bio/terra/policy/service/region/RegionServiceTest.java
@@ -37,7 +37,7 @@ public class RegionServiceTest extends TestUnitBase {
 
   @Test
   void getRegionInvalidRegionReturnsNull() {
-    String searchRegion = "invalid ";
+    String searchRegion = "invalid";
     Region result = regionService.getRegion(searchRegion);
     assertNull(result);
   }

--- a/service/src/test/java/bio/terra/policy/service/region/RegionServiceTest.java
+++ b/service/src/test/java/bio/terra/policy/service/region/RegionServiceTest.java
@@ -37,7 +37,7 @@ public class RegionServiceTest extends TestUnitBase {
 
   @Test
   void getRegionInvalidRegionReturnsNull() {
-    String searchRegion = "invalid";
+    String searchRegion = "invalid ";
     Region result = regionService.getRegion(searchRegion);
     assertNull(result);
   }


### PR DESCRIPTION
Code wasn't checking for null data centers, so there was an error when the ontology was called for a region which contains no data centers. That included the global/default region.