### PR TITLE
[PF-2478] Only run checks when PR targets default branch

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,21 +1,13 @@
 name: Build and Test
 
 on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - '*.md'
-      - '.github/**'
-  pull_request:
-    branches: [ '**' ]
-    # There is an issue with GitHub required checks and paths-ignore. We don't really need to
-    # run the tests if there are only irrelevant changes (see paths-ignore above). However,
-    # we require tests to pass by making a "required check" rule on the branch. If the action
-    # is not triggered, the required check never passes and you are stuck. Therefore, we have
-    # to run tests even when we only change a markdown file. So don't do what I did and put a
-    # paths-ignore right here!
   workflow_dispatch: {}
+  push:
+    branches: [ main ]
+    paths-ignore: [ '**.md' ]
+  pull_request:
+    # Branch settings require status checks before merging, so don't add paths-ignore.
+    branches: [ main ]
 
 jobs:
   bump-check:

--- a/.github/workflows/linter-tests.yml
+++ b/.github/workflows/linter-tests.yml
@@ -1,12 +1,13 @@
 name: Run linter tests
+
 on:
   workflow_dispatch: {}
   push:
-    branches:
-    - main
+    branches: [ main ]
+    paths-ignore: [ '*.md' ]
   pull_request:
-    branches:
-    - '**'
+    # Branch settings require status checks before merging, so don't add paths-ignore.
+    branches: [ main ]
 
 jobs:
   lint-and-static-analysis:


### PR DESCRIPTION
Only run PR checks when the PR targets primary/default branch

currently, all PRs (irrespective of the branch they target) automatically trigger PR checks. This is unnecessary and may cause the checks to be queued up on GitHub runner.

ref - 
- https://github.com/DataBiosphere/terra-workspace-manager/pull/1061
- https://broadworkbench.atlassian.net/browse/PF-2478