### PR TITLE
PF-2498: disallow combining group constraint when destination is empty

### DIFF
--- a/service/src/main/java/bio/terra/policy/service/pao/PaoService.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/PaoService.java
@@ -326,18 +326,13 @@ public class PaoService {
 
     for (PolicyInput input : sourcePao.getAttributes().getInputs().values()) {
       PolicyInput destinationMatchedPolicy = policyInputs.lookupPolicy(input);
-      // If the policy does not exist in the destination, so we add it
-      if (destinationMatchedPolicy == null) {
-        policyInputs.addInput(input);
+      PolicyInput resultInput = PolicyMutator.combine(destinationMatchedPolicy, input);
+      if (resultInput == null) {
+        // Uh oh, we hit a conflict
+        conflicts.add(new PolicyConflict(destinationPao, sourcePao, input.getPolicyName()));
       } else {
-        PolicyInput resultInput = PolicyMutator.combine(destinationMatchedPolicy, input);
-        if (resultInput == null) {
-          // Uh oh, we hit a conflict
-          conflicts.add(new PolicyConflict(destinationPao, sourcePao, input.getPolicyName()));
-        } else {
-          // Replace the policy with the combined policy
-          policyInputs.addInput(resultInput);
-        }
+        // Replace the policy with the combined policy
+        policyInputs.addInput(resultInput);
       }
     }
 

--- a/service/src/main/java/bio/terra/policy/service/policy/PolicyGroupConstraint.java
+++ b/service/src/main/java/bio/terra/policy/service/policy/PolicyGroupConstraint.java
@@ -29,6 +29,11 @@ public class PolicyGroupConstraint implements PolicyBase {
    */
   @Override
   public PolicyInput combine(PolicyInput dependent, PolicyInput source) {
+    if (source == null || dependent == null) {
+      // We can't modify the groups. If the dependent is empty, we need to leave it empty.
+      return dependent;
+    }
+
     Set<String> dependentSet = dataToSet(dependent.getData(DATA_KEY));
     Set<String> sourceSet = dataToSet(source.getData(DATA_KEY));
 

--- a/service/src/main/java/bio/terra/policy/service/policy/PolicyGroupConstraint.java
+++ b/service/src/main/java/bio/terra/policy/service/policy/PolicyGroupConstraint.java
@@ -34,7 +34,8 @@ public class PolicyGroupConstraint implements PolicyBase {
     }
 
     if (dependent == null) {
-      // We can't modify the groups. If the dependent is empty, we can't add to it so the result is a conflict.
+      // We can't modify the groups. If the dependent is empty, we can't add to it so the result is
+      // a conflict.
       return null;
     }
 

--- a/service/src/main/java/bio/terra/policy/service/policy/PolicyGroupConstraint.java
+++ b/service/src/main/java/bio/terra/policy/service/policy/PolicyGroupConstraint.java
@@ -29,9 +29,13 @@ public class PolicyGroupConstraint implements PolicyBase {
    */
   @Override
   public PolicyInput combine(PolicyInput dependent, PolicyInput source) {
-    if (source == null || dependent == null) {
-      // We can't modify the groups. If the dependent is empty, we need to leave it empty.
+    if (source == null) {
       return dependent;
+    }
+
+    if (dependent == null) {
+      // We can't modify the groups. If the dependent is empty, we can't add to it so the result is a conflict.
+      return null;
     }
 
     Set<String> dependentSet = dataToSet(dependent.getData(DATA_KEY));

--- a/service/src/main/java/bio/terra/policy/service/policy/PolicyMutator.java
+++ b/service/src/main/java/bio/terra/policy/service/policy/PolicyMutator.java
@@ -25,12 +25,12 @@ public class PolicyMutator {
    */
   public static PolicyInput combine(PolicyInput target, PolicyInput addPolicy) {
     validateMatchedPolicies(target, addPolicy);
-    return findPolicy(target == null ? addPolicy : target).combine(target, addPolicy);
+    return findPolicy(addPolicy).combine(target, addPolicy);
   }
 
   public static PolicyInput remove(PolicyInput target, PolicyInput removePolicy) {
     validateMatchedPolicies(target, removePolicy);
-    return findPolicy(target == null ? removePolicy : target).remove(target, removePolicy);
+    return findPolicy(removePolicy).remove(target, removePolicy);
   }
 
   private static void validateMatchedPolicies(PolicyInput one, PolicyInput two) {

--- a/service/src/main/java/bio/terra/policy/service/policy/PolicyMutator.java
+++ b/service/src/main/java/bio/terra/policy/service/policy/PolicyMutator.java
@@ -25,15 +25,19 @@ public class PolicyMutator {
    */
   public static PolicyInput combine(PolicyInput target, PolicyInput addPolicy) {
     validateMatchedPolicies(target, addPolicy);
-    return findPolicy(target).combine(target, addPolicy);
+    return findPolicy(target == null ? addPolicy : target).combine(target, addPolicy);
   }
 
   public static PolicyInput remove(PolicyInput target, PolicyInput removePolicy) {
     validateMatchedPolicies(target, removePolicy);
-    return findPolicy(target).remove(target, removePolicy);
+    return findPolicy(target == null ? removePolicy : target).remove(target, removePolicy);
   }
 
   private static void validateMatchedPolicies(PolicyInput one, PolicyInput two) {
+    if (one == null || two == null) {
+      // We can still call combine if one of the policies is empty.
+      return;
+    }
     // Ensure that the inputs are combine-able; this shouldn't happen, but... belts and suspenders.
     if (!StringUtils.equals(one.getKey(), two.getKey())) {
       throw new InternalTpsErrorException("Policies have different policy keys");

--- a/service/src/main/java/bio/terra/policy/service/policy/PolicyRegionConstraint.java
+++ b/service/src/main/java/bio/terra/policy/service/policy/PolicyRegionConstraint.java
@@ -34,6 +34,14 @@ public class PolicyRegionConstraint implements PolicyBase {
    */
   @Override
   public PolicyInput combine(PolicyInput dependent, PolicyInput source) {
+    if (dependent == null) {
+      return source;
+    }
+
+    if (source == null) {
+      return dependent;
+    }
+
     Set<String> dependentSet = dataToSet(dependent.getData(DATA_KEY));
     Set<String> sourceSet = dataToSet(source.getData(DATA_KEY));
     int sourceSize = sourceSet.size();

--- a/service/src/main/java/bio/terra/policy/service/policy/PolicyUnknown.java
+++ b/service/src/main/java/bio/terra/policy/service/policy/PolicyUnknown.java
@@ -32,6 +32,13 @@ public class PolicyUnknown implements PolicyBase {
    */
   @Override
   public PolicyInput combine(PolicyInput dependent, PolicyInput source) {
+    if (dependent == null) {
+      return source;
+    }
+    if (source == null) {
+      return dependent;
+    }
+
     Multimap<String, String> dependentData = dependent.getAdditionalData();
     Multimap<String, String> sourceData = source.getAdditionalData();
     Multimap<String, String> newData = ArrayListMultimap.create();

--- a/service/src/test/java/bio/terra/policy/service/policy/PolicyGroupConstraintTest.java
+++ b/service/src/test/java/bio/terra/policy/service/policy/PolicyGroupConstraintTest.java
@@ -40,17 +40,24 @@ public class PolicyGroupConstraintTest extends TestUnitBase {
     var dependentPolicy =
         new PolicyInput(TERRA, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, GROUP_NAME));
 
-    // source policy has no group constraint.
-    var sourcePolicy =
-        new PolicyInput(TERRA, REGION_CONSTRAINT, buildMultimap(REGION_KEY, GROUP_NAME));
-
-    PolicyInput resultPolicy = groupConstraint.combine(dependentPolicy, sourcePolicy);
+    PolicyInput resultPolicy = groupConstraint.combine(dependentPolicy, null);
 
     Set<String> groupSet =
         groupConstraint.dataToSet(resultPolicy.getAdditionalData().get(GROUP_KEY));
 
     assertEquals(1, groupSet.size(), "Contains 1 group");
     assertThat(groupSet, contains(GROUP_NAME));
+  }
+
+  @Test
+  void groupConstraintTest_combineEmptyDestination() throws Exception {
+    var groupConstraint = new PolicyGroupConstraint();
+
+    var sourcePolicy =
+        new PolicyInput(TERRA, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, GROUP_NAME));
+
+    PolicyInput resultPolicy = groupConstraint.combine(null, sourcePolicy);
+    assertNull(resultPolicy);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/policy/service/policy/PolicyRegionConstraintTest.java
+++ b/service/src/test/java/bio/terra/policy/service/policy/PolicyRegionConstraintTest.java
@@ -68,9 +68,6 @@ public class PolicyRegionConstraintTest extends TestUnitBase {
 
     var sourceRegion = "germany";
 
-    // dependent only has a group constraint
-    var dependentPolicy =
-        new PolicyInput(TERRA, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, GROUP_NAME));
     var sourcePolicy =
         new PolicyInput(TERRA, REGION_CONSTRAINT, buildMultimap(REGION_KEY, sourceRegion));
 

--- a/service/src/test/java/bio/terra/policy/service/policy/PolicyRegionConstraintTest.java
+++ b/service/src/test/java/bio/terra/policy/service/policy/PolicyRegionConstraintTest.java
@@ -74,7 +74,7 @@ public class PolicyRegionConstraintTest extends TestUnitBase {
     var sourcePolicy =
         new PolicyInput(TERRA, REGION_CONSTRAINT, buildMultimap(REGION_KEY, sourceRegion));
 
-    PolicyInput resultPolicy = regionConstraint.combine(dependentPolicy, sourcePolicy);
+    PolicyInput resultPolicy = regionConstraint.combine(null, sourcePolicy);
 
     Set<String> groupSet =
         regionConstraint.dataToSet(resultPolicy.getAdditionalData().get(REGION_KEY));
@@ -91,11 +91,7 @@ public class PolicyRegionConstraintTest extends TestUnitBase {
     var dependentPolicy =
         new PolicyInput(TERRA, REGION_CONSTRAINT, buildMultimap(REGION_KEY, dependentRegion));
 
-    // source only has a group constraint
-    var sourcePolicy =
-        new PolicyInput(TERRA, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, GROUP_NAME));
-
-    PolicyInput resultPolicy = regionConstraint.combine(dependentPolicy, sourcePolicy);
+    PolicyInput resultPolicy = regionConstraint.combine(dependentPolicy, null);
 
     Set<String> groupSet =
         regionConstraint.dataToSet(resultPolicy.getAdditionalData().get(REGION_KEY));


### PR DESCRIPTION
For group constraints, we have the requirement where we should not allow a Workspace with no group constraint to combine with a Data Collection that has a different group constraint. The default behavior allowed this.