### PR TITLE
PF-2509: update PAO overwrites existing attributes

### DIFF
--- a/service/src/main/java/bio/terra/policy/service/pao/PaoService.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/PaoService.java
@@ -237,18 +237,18 @@ public class PaoService {
         updateMode);
 
     Pao targetPao = paoDao.getPao(targetPaoId);
-    PolicyInputs newAttributes = targetPao.getAttributes();
+    PolicyInputs attributesToUpdate = targetPao.getAttributes();
 
     // We do the removes first, so we don't remove newly added things
     for (PolicyInput removePolicy : removeAttributes.getInputs().values()) {
       PolicyInput existingPolicy = targetPao.getAttributes().lookupPolicy(removePolicy);
       if (existingPolicy != null) {
         // We have something to remove
-        newAttributes.removeInput(existingPolicy);
+        attributesToUpdate.removeInput(existingPolicy);
         PolicyInput removeResult = PolicyMutator.remove(existingPolicy, removePolicy);
         if (removeResult != null) {
           // There is something left of the policy to keep
-          newAttributes.addInput(removeResult);
+          attributesToUpdate.addInput(removeResult);
         }
       }
     }
@@ -258,13 +258,13 @@ public class PaoService {
       PolicyInput existingPolicy = targetPao.getAttributes().lookupPolicy(addPolicy);
       if (existingPolicy == null) {
         // Nothing to combine; just take the new
-        newAttributes.addInput(addPolicy);
+        attributesToUpdate.addInput(addPolicy);
       } else {
         PolicyInput addResult = PolicyMutator.combine(existingPolicy, addPolicy);
         if (addResult != null) {
           // We have a combined policy to add
-          newAttributes.removeInput(existingPolicy);
-          newAttributes.addInput(addResult);
+          attributesToUpdate.removeInput(existingPolicy);
+          attributesToUpdate.addInput(addResult);
         } else {
           throw new DirectConflictException(
               String.format(
@@ -274,7 +274,7 @@ public class PaoService {
       }
     }
 
-    return updateAttributesWorker(newAttributes, targetPao, updateMode);
+    return updateAttributesWorker(attributesToUpdate, targetPao, updateMode);
   }
 
   // Common code to update new attributes to a targetPao

--- a/service/src/main/java/bio/terra/policy/service/pao/PaoService.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/PaoService.java
@@ -237,13 +237,14 @@ public class PaoService {
         updateMode);
 
     Pao targetPao = paoDao.getPao(targetPaoId);
-    PolicyInputs newAttributes = new PolicyInputs();
+    PolicyInputs newAttributes = targetPao.getAttributes();
 
     // We do the removes first, so we don't remove newly added things
     for (PolicyInput removePolicy : removeAttributes.getInputs().values()) {
       PolicyInput existingPolicy = targetPao.getAttributes().lookupPolicy(removePolicy);
       if (existingPolicy != null) {
         // We have something to remove
+        newAttributes.removeInput(existingPolicy);
         PolicyInput removeResult = PolicyMutator.remove(existingPolicy, removePolicy);
         if (removeResult != null) {
           // There is something left of the policy to keep
@@ -262,6 +263,7 @@ public class PaoService {
         PolicyInput addResult = PolicyMutator.combine(existingPolicy, addPolicy);
         if (addResult != null) {
           // We have a combined policy to add
+          newAttributes.removeInput(existingPolicy);
           newAttributes.addInput(addResult);
         } else {
           throw new DirectConflictException(

--- a/service/src/test/java/bio/terra/policy/service/pao/PaoUpdateTest.java
+++ b/service/src/test/java/bio/terra/policy/service/pao/PaoUpdateTest.java
@@ -345,7 +345,8 @@ public class PaoUpdateTest extends TestUnitBase {
     PolicyInputs groupPolicyInput = PaoTestUtil.makePolicyInputs(groupPolicy);
 
     PolicyUpdateResult result =
-        paoService.updatePao(paoId, groupPolicyInput, new PolicyInputs(), PaoUpdateMode.FAIL_ON_CONFLICT);
+        paoService.updatePao(
+            paoId, groupPolicyInput, new PolicyInputs(), PaoUpdateMode.FAIL_ON_CONFLICT);
     logger.info("Update 1 adds a group constraint. Result: {}", result);
 
     assertTrue(result.updateApplied());

--- a/service/src/test/java/bio/terra/policy/service/pao/PaoUpdateTest.java
+++ b/service/src/test/java/bio/terra/policy/service/pao/PaoUpdateTest.java
@@ -340,12 +340,12 @@ public class PaoUpdateTest extends TestUnitBase {
             TERRA_NAMESPACE, GROUP_CONSTRAINT, Collections.singletonMap(GROUP_KEY, GROUP_NAME));
 
     UUID paoId = PaoTestUtil.makePao(paoService, regionPolicy);
-    logger.info("paoId: {}", paoId);
+    logger.info("make pao {} with region policy", paoId);
 
-    PolicyInputs adds = PaoTestUtil.makePolicyInputs(groupPolicy);
+    PolicyInputs groupPolicyInput = PaoTestUtil.makePolicyInputs(groupPolicy);
 
     PolicyUpdateResult result =
-        paoService.updatePao(paoId, adds, new PolicyInputs(), PaoUpdateMode.FAIL_ON_CONFLICT);
+        paoService.updatePao(paoId, groupPolicyInput, new PolicyInputs(), PaoUpdateMode.FAIL_ON_CONFLICT);
     logger.info("Update 1 adds a group constraint. Result: {}", result);
 
     assertTrue(result.updateApplied());

--- a/service/src/test/java/bio/terra/policy/service/policy/PolicyGroupConstraintTest.java
+++ b/service/src/test/java/bio/terra/policy/service/policy/PolicyGroupConstraintTest.java
@@ -1,6 +1,12 @@
 package bio.terra.policy.service.policy;
 
 import static bio.terra.policy.service.policy.PolicyTestUtils.*;
+import static bio.terra.policy.testutils.PaoTestUtil.GROUP_CONSTRAINT;
+import static bio.terra.policy.testutils.PaoTestUtil.GROUP_KEY;
+import static bio.terra.policy.testutils.PaoTestUtil.GROUP_NAME;
+import static bio.terra.policy.testutils.PaoTestUtil.REGION_CONSTRAINT;
+import static bio.terra.policy.testutils.PaoTestUtil.REGION_KEY;
+import static bio.terra.policy.testutils.PaoTestUtil.TERRA_NAMESPACE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -20,9 +26,9 @@ public class PolicyGroupConstraintTest extends TestUnitBase {
     var groupConstraint = new PolicyGroupConstraint();
 
     var dependentPolicy =
-        new PolicyInput(TERRA, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, GROUP_NAME));
+        new PolicyInput(TERRA_NAMESPACE, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, GROUP_NAME));
     var sourcePolicy =
-        new PolicyInput(TERRA, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, GROUP_NAME));
+        new PolicyInput(TERRA_NAMESPACE, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, GROUP_NAME));
 
     PolicyInput resultPolicy = groupConstraint.combine(dependentPolicy, sourcePolicy);
 
@@ -38,7 +44,7 @@ public class PolicyGroupConstraintTest extends TestUnitBase {
     var groupConstraint = new PolicyGroupConstraint();
 
     var dependentPolicy =
-        new PolicyInput(TERRA, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, GROUP_NAME));
+        new PolicyInput(TERRA_NAMESPACE, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, GROUP_NAME));
 
     PolicyInput resultPolicy = groupConstraint.combine(dependentPolicy, null);
 
@@ -54,7 +60,7 @@ public class PolicyGroupConstraintTest extends TestUnitBase {
     var groupConstraint = new PolicyGroupConstraint();
 
     var sourcePolicy =
-        new PolicyInput(TERRA, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, GROUP_NAME));
+        new PolicyInput(TERRA_NAMESPACE, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, GROUP_NAME));
 
     PolicyInput resultPolicy = groupConstraint.combine(null, sourcePolicy);
     assertNull(resultPolicy);
@@ -66,9 +72,9 @@ public class PolicyGroupConstraintTest extends TestUnitBase {
 
     // Only adding region constraints.
     var dependentPolicy =
-        new PolicyInput(TERRA, REGION_CONSTRAINT, buildMultimap(REGION_KEY, GROUP_NAME));
+        new PolicyInput(TERRA_NAMESPACE, REGION_CONSTRAINT, buildMultimap(REGION_KEY, GROUP_NAME));
     var sourcePolicy =
-        new PolicyInput(TERRA, REGION_CONSTRAINT, buildMultimap(REGION_KEY, GROUP_NAME));
+        new PolicyInput(TERRA_NAMESPACE, REGION_CONSTRAINT, buildMultimap(REGION_KEY, GROUP_NAME));
 
     PolicyInput resultPolicy = groupConstraint.combine(dependentPolicy, sourcePolicy);
 
@@ -83,9 +89,10 @@ public class PolicyGroupConstraintTest extends TestUnitBase {
     var groupConstraint = new PolicyGroupConstraint();
 
     var dependentPolicy =
-        new PolicyInput(TERRA, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, GROUP_NAME));
+        new PolicyInput(TERRA_NAMESPACE, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, GROUP_NAME));
     var sourcePolicy =
-        new PolicyInput(TERRA, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, GROUP_NAME + "a"));
+        new PolicyInput(
+            TERRA_NAMESPACE, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, GROUP_NAME + "a"));
 
     PolicyInput resultPolicy = groupConstraint.combine(dependentPolicy, sourcePolicy);
     assertNull(resultPolicy);
@@ -101,8 +108,9 @@ public class PolicyGroupConstraintTest extends TestUnitBase {
     Set<String> groups = new HashSet<>(Arrays.asList(GROUP_NAME, group2, group3));
 
     var dependentPolicy =
-        new PolicyInput(TERRA, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, groups));
-    var sourcePolicy = new PolicyInput(TERRA, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, groups));
+        new PolicyInput(TERRA_NAMESPACE, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, groups));
+    var sourcePolicy =
+        new PolicyInput(TERRA_NAMESPACE, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, groups));
 
     PolicyInput resultPolicy = groupConstraint.combine(dependentPolicy, sourcePolicy);
 
@@ -123,10 +131,11 @@ public class PolicyGroupConstraintTest extends TestUnitBase {
     Set<String> groups = new HashSet<>(Arrays.asList(GROUP_NAME, group2));
 
     var dependentPolicy =
-        new PolicyInput(TERRA, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, groups));
+        new PolicyInput(TERRA_NAMESPACE, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, groups));
 
     groups.add(group3);
-    var sourcePolicy = new PolicyInput(TERRA, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, groups));
+    var sourcePolicy =
+        new PolicyInput(TERRA_NAMESPACE, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, groups));
 
     PolicyInput resultPolicy = groupConstraint.combine(dependentPolicy, sourcePolicy);
     assertNull(resultPolicy);
@@ -142,10 +151,11 @@ public class PolicyGroupConstraintTest extends TestUnitBase {
     Set<String> groups = new HashSet<>(Arrays.asList(GROUP_NAME, group2, group3));
 
     var dependentPolicy =
-        new PolicyInput(TERRA, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, groups));
+        new PolicyInput(TERRA_NAMESPACE, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, groups));
 
     groups.remove(group3);
-    var sourcePolicy = new PolicyInput(TERRA, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, groups));
+    var sourcePolicy =
+        new PolicyInput(TERRA_NAMESPACE, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, groups));
 
     PolicyInput resultPolicy = groupConstraint.combine(dependentPolicy, sourcePolicy);
     assertNull(resultPolicy);
@@ -159,11 +169,13 @@ public class PolicyGroupConstraintTest extends TestUnitBase {
     String group3 = GROUP_NAME + "3";
 
     Set<String> groups = new HashSet<>(Arrays.asList(GROUP_NAME));
-    var removePolicy = new PolicyInput(TERRA, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, groups));
+    var removePolicy =
+        new PolicyInput(TERRA_NAMESPACE, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, groups));
 
     groups.add(group2);
     groups.add(group3);
-    var targetPolicy = new PolicyInput(TERRA, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, groups));
+    var targetPolicy =
+        new PolicyInput(TERRA_NAMESPACE, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, groups));
 
     PolicyInput resultPolicy = groupConstraint.remove(targetPolicy, removePolicy);
     Set<String> groupSet =
@@ -179,12 +191,13 @@ public class PolicyGroupConstraintTest extends TestUnitBase {
     var groupConstraint = new PolicyGroupConstraint();
 
     var removePolicy =
-        new PolicyInput(TERRA, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, GROUP_NAME));
+        new PolicyInput(TERRA_NAMESPACE, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, GROUP_NAME));
 
     String group2 = GROUP_NAME + "2";
     String group3 = GROUP_NAME + "3";
     Set<String> groups = new HashSet<>(Arrays.asList(group2, group3));
-    var targetPolicy = new PolicyInput(TERRA, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, groups));
+    var targetPolicy =
+        new PolicyInput(TERRA_NAMESPACE, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, groups));
 
     // we never added GROUP_NAME into the policy, removing it shouldn't break.
     PolicyInput resultPolicy = groupConstraint.remove(targetPolicy, removePolicy);
@@ -201,8 +214,10 @@ public class PolicyGroupConstraintTest extends TestUnitBase {
     var groupConstraint = new PolicyGroupConstraint();
 
     Set<String> groups = new HashSet<>(Arrays.asList(GROUP_NAME));
-    var removePolicy = new PolicyInput(TERRA, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, groups));
-    var targetPolicy = new PolicyInput(TERRA, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, groups));
+    var removePolicy =
+        new PolicyInput(TERRA_NAMESPACE, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, groups));
+    var targetPolicy =
+        new PolicyInput(TERRA_NAMESPACE, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, groups));
 
     PolicyInput resultPolicy = groupConstraint.remove(targetPolicy, removePolicy);
     assertNull(resultPolicy);

--- a/service/src/test/java/bio/terra/policy/service/policy/PolicyRegionConstraintTest.java
+++ b/service/src/test/java/bio/terra/policy/service/policy/PolicyRegionConstraintTest.java
@@ -1,12 +1,12 @@
 package bio.terra.policy.service.policy;
 
-import static bio.terra.policy.service.policy.PolicyTestUtils.GROUP_CONSTRAINT;
-import static bio.terra.policy.service.policy.PolicyTestUtils.GROUP_KEY;
-import static bio.terra.policy.service.policy.PolicyTestUtils.GROUP_NAME;
-import static bio.terra.policy.service.policy.PolicyTestUtils.REGION_CONSTRAINT;
-import static bio.terra.policy.service.policy.PolicyTestUtils.REGION_KEY;
-import static bio.terra.policy.service.policy.PolicyTestUtils.TERRA;
 import static bio.terra.policy.service.policy.PolicyTestUtils.buildMultimap;
+import static bio.terra.policy.testutils.PaoTestUtil.GROUP_CONSTRAINT;
+import static bio.terra.policy.testutils.PaoTestUtil.GROUP_KEY;
+import static bio.terra.policy.testutils.PaoTestUtil.GROUP_NAME;
+import static bio.terra.policy.testutils.PaoTestUtil.REGION_CONSTRAINT;
+import static bio.terra.policy.testutils.PaoTestUtil.REGION_KEY;
+import static bio.terra.policy.testutils.PaoTestUtil.TERRA_NAMESPACE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -30,9 +30,9 @@ public class PolicyRegionConstraintTest extends TestUnitBase {
     var region2 = region1;
 
     var dependentPolicy =
-        new PolicyInput(TERRA, REGION_CONSTRAINT, buildMultimap(REGION_KEY, region1));
+        new PolicyInput(TERRA_NAMESPACE, REGION_CONSTRAINT, buildMultimap(REGION_KEY, region1));
     var sourcePolicy =
-        new PolicyInput(TERRA, REGION_CONSTRAINT, buildMultimap(REGION_KEY, region2));
+        new PolicyInput(TERRA_NAMESPACE, REGION_CONSTRAINT, buildMultimap(REGION_KEY, region2));
 
     PolicyInput resultPolicy = regionConstraint.combine(dependentPolicy, sourcePolicy);
 
@@ -50,9 +50,9 @@ public class PolicyRegionConstraintTest extends TestUnitBase {
     var region2 = "germany";
 
     var dependentPolicy =
-        new PolicyInput(TERRA, REGION_CONSTRAINT, buildMultimap(REGION_KEY, region1));
+        new PolicyInput(TERRA_NAMESPACE, REGION_CONSTRAINT, buildMultimap(REGION_KEY, region1));
     var sourcePolicy =
-        new PolicyInput(TERRA, REGION_CONSTRAINT, buildMultimap(REGION_KEY, region2));
+        new PolicyInput(TERRA_NAMESPACE, REGION_CONSTRAINT, buildMultimap(REGION_KEY, region2));
 
     PolicyInput resultPolicy = regionConstraint.combine(dependentPolicy, sourcePolicy);
 
@@ -69,7 +69,8 @@ public class PolicyRegionConstraintTest extends TestUnitBase {
     var sourceRegion = "germany";
 
     var sourcePolicy =
-        new PolicyInput(TERRA, REGION_CONSTRAINT, buildMultimap(REGION_KEY, sourceRegion));
+        new PolicyInput(
+            TERRA_NAMESPACE, REGION_CONSTRAINT, buildMultimap(REGION_KEY, sourceRegion));
 
     PolicyInput resultPolicy = regionConstraint.combine(null, sourcePolicy);
 
@@ -86,7 +87,8 @@ public class PolicyRegionConstraintTest extends TestUnitBase {
     var dependentRegion = "germany";
 
     var dependentPolicy =
-        new PolicyInput(TERRA, REGION_CONSTRAINT, buildMultimap(REGION_KEY, dependentRegion));
+        new PolicyInput(
+            TERRA_NAMESPACE, REGION_CONSTRAINT, buildMultimap(REGION_KEY, dependentRegion));
 
     PolicyInput resultPolicy = regionConstraint.combine(dependentPolicy, null);
 
@@ -102,9 +104,9 @@ public class PolicyRegionConstraintTest extends TestUnitBase {
 
     // neither input contains a region constraint
     var dependentPolicy =
-        new PolicyInput(TERRA, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, GROUP_NAME));
+        new PolicyInput(TERRA_NAMESPACE, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, GROUP_NAME));
     var sourcePolicy =
-        new PolicyInput(TERRA, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, GROUP_NAME));
+        new PolicyInput(TERRA_NAMESPACE, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, GROUP_NAME));
 
     PolicyInput resultPolicy = regionConstraint.combine(dependentPolicy, sourcePolicy);
 
@@ -121,9 +123,11 @@ public class PolicyRegionConstraintTest extends TestUnitBase {
     Set<String> sourceRegions = new HashSet<>(Arrays.asList("uk", "gcp.us-central1", "japan"));
 
     var dependentPolicy =
-        new PolicyInput(TERRA, REGION_CONSTRAINT, buildMultimap(REGION_KEY, dependentRegions));
+        new PolicyInput(
+            TERRA_NAMESPACE, REGION_CONSTRAINT, buildMultimap(REGION_KEY, dependentRegions));
     var sourcePolicy =
-        new PolicyInput(TERRA, REGION_CONSTRAINT, buildMultimap(REGION_KEY, sourceRegions));
+        new PolicyInput(
+            TERRA_NAMESPACE, REGION_CONSTRAINT, buildMultimap(REGION_KEY, sourceRegions));
 
     PolicyInput resultPolicy = regionConstraint.combine(dependentPolicy, sourcePolicy);
 
@@ -142,9 +146,11 @@ public class PolicyRegionConstraintTest extends TestUnitBase {
     Set<String> sourceRegions = new HashSet<>(Arrays.asList("americas", "asiapacific", "europe"));
 
     var dependentPolicy =
-        new PolicyInput(TERRA, REGION_CONSTRAINT, buildMultimap(REGION_KEY, dependentRegions));
+        new PolicyInput(
+            TERRA_NAMESPACE, REGION_CONSTRAINT, buildMultimap(REGION_KEY, dependentRegions));
     var sourcePolicy =
-        new PolicyInput(TERRA, REGION_CONSTRAINT, buildMultimap(REGION_KEY, sourceRegions));
+        new PolicyInput(
+            TERRA_NAMESPACE, REGION_CONSTRAINT, buildMultimap(REGION_KEY, sourceRegions));
 
     PolicyInput resultPolicy = regionConstraint.combine(dependentPolicy, sourcePolicy);
 
@@ -164,9 +170,11 @@ public class PolicyRegionConstraintTest extends TestUnitBase {
     Set<String> expectedResult = new HashSet<>(Arrays.asList("uk", "finland"));
 
     var dependentPolicy =
-        new PolicyInput(TERRA, REGION_CONSTRAINT, buildMultimap(REGION_KEY, dependentRegions));
+        new PolicyInput(
+            TERRA_NAMESPACE, REGION_CONSTRAINT, buildMultimap(REGION_KEY, dependentRegions));
     var sourcePolicy =
-        new PolicyInput(TERRA, REGION_CONSTRAINT, buildMultimap(REGION_KEY, sourceRegions));
+        new PolicyInput(
+            TERRA_NAMESPACE, REGION_CONSTRAINT, buildMultimap(REGION_KEY, sourceRegions));
 
     PolicyInput resultPolicy = regionConstraint.combine(dependentPolicy, sourcePolicy);
 
@@ -187,9 +195,11 @@ public class PolicyRegionConstraintTest extends TestUnitBase {
     Set<String> expectedResult = new HashSet<>(Arrays.asList("uk", "finland"));
 
     var dependentPolicy =
-        new PolicyInput(TERRA, REGION_CONSTRAINT, buildMultimap(REGION_KEY, dependentRegions));
+        new PolicyInput(
+            TERRA_NAMESPACE, REGION_CONSTRAINT, buildMultimap(REGION_KEY, dependentRegions));
     var sourcePolicy =
-        new PolicyInput(TERRA, REGION_CONSTRAINT, buildMultimap(REGION_KEY, sourceRegions));
+        new PolicyInput(
+            TERRA_NAMESPACE, REGION_CONSTRAINT, buildMultimap(REGION_KEY, sourceRegions));
 
     PolicyInput resultPolicy = regionConstraint.combine(dependentPolicy, sourcePolicy);
 
@@ -208,9 +218,11 @@ public class PolicyRegionConstraintTest extends TestUnitBase {
     Set<String> sourceRegions = new HashSet<>(Arrays.asList("europe"));
 
     var dependentPolicy =
-        new PolicyInput(TERRA, REGION_CONSTRAINT, buildMultimap(REGION_KEY, dependentRegions));
+        new PolicyInput(
+            TERRA_NAMESPACE, REGION_CONSTRAINT, buildMultimap(REGION_KEY, dependentRegions));
     var sourcePolicy =
-        new PolicyInput(TERRA, REGION_CONSTRAINT, buildMultimap(REGION_KEY, sourceRegions));
+        new PolicyInput(
+            TERRA_NAMESPACE, REGION_CONSTRAINT, buildMultimap(REGION_KEY, sourceRegions));
 
     PolicyInput resultPolicy = regionConstraint.combine(dependentPolicy, sourcePolicy);
 
@@ -225,9 +237,10 @@ public class PolicyRegionConstraintTest extends TestUnitBase {
     var region2 = "usa";
 
     var targetPolicy =
-        new PolicyInput(TERRA, REGION_CONSTRAINT, buildMultimap(REGION_KEY, region1, region2));
+        new PolicyInput(
+            TERRA_NAMESPACE, REGION_CONSTRAINT, buildMultimap(REGION_KEY, region1, region2));
     var removePolicy =
-        new PolicyInput(TERRA, REGION_CONSTRAINT, buildMultimap(REGION_KEY, region2));
+        new PolicyInput(TERRA_NAMESPACE, REGION_CONSTRAINT, buildMultimap(REGION_KEY, region2));
 
     PolicyInput resultPolicy = regionConstraint.remove(targetPolicy, removePolicy);
     Set<String> groupSet =
@@ -243,9 +256,9 @@ public class PolicyRegionConstraintTest extends TestUnitBase {
     var region1 = "europe";
 
     var targetPolicy =
-        new PolicyInput(TERRA, REGION_CONSTRAINT, buildMultimap(REGION_KEY, region1));
+        new PolicyInput(TERRA_NAMESPACE, REGION_CONSTRAINT, buildMultimap(REGION_KEY, region1));
     var removePolicy =
-        new PolicyInput(TERRA, REGION_CONSTRAINT, buildMultimap(REGION_KEY, region1));
+        new PolicyInput(TERRA_NAMESPACE, REGION_CONSTRAINT, buildMultimap(REGION_KEY, region1));
 
     PolicyInput resultPolicy = regionConstraint.remove(targetPolicy, removePolicy);
     assertNull(resultPolicy);

--- a/service/src/test/java/bio/terra/policy/service/policy/PolicyTestUtils.java
+++ b/service/src/test/java/bio/terra/policy/service/policy/PolicyTestUtils.java
@@ -5,14 +5,6 @@ import com.google.common.collect.Multimap;
 import java.util.Set;
 
 public class PolicyTestUtils {
-
-  protected static final String TERRA = "terra";
-  protected static final String REGION_KEY = "region-name";
-  protected static final String REGION_CONSTRAINT = "region-constraint";
-  protected static final String GROUP_CONSTRAINT = "group-constraint";
-  protected static final String GROUP_KEY = "group";
-  protected static final String GROUP_NAME = "mygroup";
-
   protected static Multimap<String, String> buildMultimap(String key, String... values) {
     Multimap<String, String> mm = ArrayListMultimap.create();
     for (String value : values) {

--- a/service/src/test/java/bio/terra/policy/testutils/PaoTestUtil.java
+++ b/service/src/test/java/bio/terra/policy/testutils/PaoTestUtil.java
@@ -17,6 +17,14 @@ import java.util.Collections;
 import java.util.UUID;
 
 public class PaoTestUtil {
+  public static final String TERRA_NAMESPACE = "terra";
+  public static final String REGION_CONSTRAINT = "region-constraint";
+  public static final String GROUP_CONSTRAINT = "group-constraint";
+  public static final String REGION_KEY = "region-name";
+  public static final String DEFAULT_REGION_NAME = "usa";
+  public static final String GROUP_KEY = "group";
+  public static final String GROUP_NAME = "mygroup";
+
   public static final String TEST_NAMESPACE = "test_namespace";
   public static final String TEST_FLAG_POLICY_A = "test_flag_a";
   public static final String TEST_FLAG_POLICY_B = "test_flag_b";


### PR DESCRIPTION
We were working from a blank slate and then calculating removes and adds. This change will existing set and remove/replace inputs into it as necessary.