### PR TITLE
[PF-2531] Set default client connection validation time lower

### DIFF
--- a/client/src/main/resources/swaggercodegen/libraries/jersey2/ApiClient.mustache
+++ b/client/src/main/resources/swaggercodegen/libraries/jersey2/ApiClient.mustache
@@ -827,7 +827,11 @@ public class ApiClient {
     clientConfig.connectorProvider(new ApacheConnectorProvider());
     // Note the PoolingHttpClientConnectionManager defaults to a maximum of 2 connections per route.
     // This may be too low for our use cases, but we can modify it here later if needed.
-    clientConfig.property(ApacheClientProperties.CONNECTION_MANAGER, new PoolingHttpClientConnectionManager());
+    PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
+    // Validate inactive connections after 500ms instead of default 2000ms to avoid
+    // NoHttpResponseExceptions from stale connections.
+    connectionManager.setValidateAfterInactivity(500);
+    clientConfig.property(ApacheClientProperties.CONNECTION_MANAGER, connectionManager);
     {{! End Terra change }}
   }
 


### PR DESCRIPTION
The `NoHttpResponseException`s we keep seeing indicate the TPS server (or the proxy in front of it, anyway) is closing connections that the client thinks are still open. These aren't timeouts, as the requests fail almost immediately.

This fix is a bit of a bandaid, as it doesn't address whatever is causing the TPS server to close connections (I believe that's somewhere in the Broad's proxy or ingress setup, but I can't find where. It's also different than Verily, where we don't see this issue). Instead, this makes the client more aggressive about validating connections before using them. This is enough to catch all the stale connections I've seen so far, which gets rid of all `NoHttpResponseException`s.

Tested locally and in https://github.com/DataBiosphere/terra-workspace-manager/pull/1107