### PR TITLE
[PF-2531] In default client library, always validate connection before use

### DIFF
--- a/client/src/main/resources/swaggercodegen/libraries/jersey2/ApiClient.mustache
+++ b/client/src/main/resources/swaggercodegen/libraries/jersey2/ApiClient.mustache
@@ -825,12 +825,13 @@ public class ApiClient {
     // For JDK17, we need to use this connection provider to work around the way Jersey
     // implements PATCH
     clientConfig.connectorProvider(new ApacheConnectorProvider());
-    // Note the PoolingHttpClientConnectionManager defaults to a maximum of 2 connections per route.
-    // This may be too low for our use cases, but we can modify it here later if needed.
     PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
-    // Validate inactive connections after 500ms instead of default 2000ms to avoid
-    // NoHttpResponseExceptions from stale connections.
-    connectionManager.setValidateAfterInactivity(500);
+    connectionManager.setDefaultMaxPerRoute(20);
+    // Validate inactive connections after 1ms instead of default 2000ms. This is
+    // the closest to "always validate" behavior we can get.
+    // This is a small performance hit, but avoids errors from stale connections
+    // that Terra hits otherwise.
+    connectionManager.setValidateAfterInactivity(1);
     clientConfig.property(ApacheClientProperties.CONNECTION_MANAGER, connectionManager);
     {{! End Terra change }}
   }


### PR DESCRIPTION
First, increase the max number of connections from 2 -> 20. This is a small improvement when running multiple test threads locally, so it probably also helps with live servers. This also matches the default of the previous `JdkConnectorProvider`.

Second, validate inactive connections after 1ms, which is the closest we can get to always validating connections before use, which matches older client behavior. This eliminates the `NoHttpResponseException` errors we keep seeing due to Terra servers unexpectedly (to the client, anyway) closing connections.

Tested in WSM (https://github.com/DataBiosphere/terra-workspace-manager/actions/runs/4348772074/jobs/7599148331), 