### PR TITLE
PF-2563: Disallow updating of group constraints

### DIFF
--- a/service/src/main/java/bio/terra/policy/common/model/PolicyInputs.java
+++ b/service/src/main/java/bio/terra/policy/common/model/PolicyInputs.java
@@ -17,6 +17,16 @@ public class PolicyInputs {
     this.inputs = inputs;
   }
 
+  public PolicyInputs(PolicyInputs source) {
+    this.inputs = new HashMap<>();
+
+    Map<String, PolicyInput> sourceInputs = source.getInputs();
+
+    for (String key : sourceInputs.keySet()) {
+      addInput(sourceInputs.get(key).duplicate());
+    }
+  }
+
   public PolicyInputs() {
     this.inputs = new HashMap<>();
   }

--- a/service/src/main/java/bio/terra/policy/service/pao/PaoService.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/PaoService.java
@@ -238,7 +238,7 @@ public class PaoService {
         updateMode);
 
     Pao targetPao = paoDao.getPao(targetPaoId);
-    PolicyInputs attributesToUpdate = targetPao.getAttributes();
+    PolicyInputs attributesToUpdate = new PolicyInputs(targetPao.getAttributes());
 
     // We do the removes first, so we don't remove newly added things
     for (PolicyInput removePolicy : removeAttributes.getInputs().values()) {
@@ -264,9 +264,6 @@ public class PaoService {
       PolicyInput addResult = PolicyMutator.combine(existingPolicy, addPolicy);
       if (addResult != null) {
         // We have a combined policy to add
-        if (existingPolicy != null) {
-          attributesToUpdate.removeInput(existingPolicy);
-        }
         attributesToUpdate.addInput(addResult);
       } else {
         throw new DirectConflictException(

--- a/service/src/main/java/bio/terra/policy/service/pao/PaoService.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/PaoService.java
@@ -261,21 +261,18 @@ public class PaoService {
             String.format("Invalid PolicyInput: %s", addPolicy.getKey()));
       }
       PolicyInput existingPolicy = targetPao.getAttributes().lookupPolicy(addPolicy);
-      if (existingPolicy == null) {
-        // Nothing to combine; just take the new
-        attributesToUpdate.addInput(addPolicy);
-      } else {
-        PolicyInput addResult = PolicyMutator.combine(existingPolicy, addPolicy);
-        if (addResult != null) {
-          // We have a combined policy to add
+      PolicyInput addResult = PolicyMutator.combine(existingPolicy, addPolicy);
+      if (addResult != null) {
+        // We have a combined policy to add
+        if (existingPolicy != null) {
           attributesToUpdate.removeInput(existingPolicy);
-          attributesToUpdate.addInput(addResult);
-        } else {
-          throw new DirectConflictException(
-              String.format(
-                  "Update of policy %s adding %s creates a conflict",
-                  existingPolicy.getKey(), addPolicy.getKey()));
         }
+        attributesToUpdate.addInput(addResult);
+      } else {
+        throw new DirectConflictException(
+            String.format(
+                "Update of policy %s adding %s creates a conflict",
+                existingPolicy.getKey(), addPolicy.getKey()));
       }
     }
 

--- a/service/src/main/java/bio/terra/policy/service/pao/PaoService.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/PaoService.java
@@ -260,7 +260,7 @@ public class PaoService {
         throw new InvalidInputException(
             String.format("Invalid PolicyInput: %s", addPolicy.getKey()));
       }
-      PolicyInput existingPolicy = targetPao.getAttributes().lookupPolicy(addPolicy);
+      PolicyInput existingPolicy = attributesToUpdate.lookupPolicy(addPolicy);
       PolicyInput addResult = PolicyMutator.combine(existingPolicy, addPolicy);
       if (addResult != null) {
         // We have a combined policy to add

--- a/service/src/main/java/bio/terra/policy/service/policy/PolicyGroupConstraint.java
+++ b/service/src/main/java/bio/terra/policy/service/policy/PolicyGroupConstraint.java
@@ -31,6 +31,14 @@ public class PolicyGroupConstraint implements PolicyBase {
    */
   @Override
   public PolicyInput combine(PolicyInput dependent, PolicyInput source) {
+    if (source == null) {
+      return dependent;
+    }
+
+    if (dependent == null) {
+      return source;
+    }
+
     Set<String> dependentSet = dataToSet(dependent.getData(DATA_KEY));
     Set<String> sourceSet = dataToSet(source.getData(DATA_KEY));
     dependentSet.addAll(sourceSet);

--- a/service/src/main/java/bio/terra/policy/service/policy/PolicyGroupConstraint.java
+++ b/service/src/main/java/bio/terra/policy/service/policy/PolicyGroupConstraint.java
@@ -3,8 +3,6 @@ package bio.terra.policy.service.policy;
 import bio.terra.policy.common.model.PolicyInput;
 import bio.terra.policy.common.model.PolicyName;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -51,8 +49,8 @@ public class PolicyGroupConstraint implements PolicyBase {
   }
 
   /**
-   * Remove groups - remove groups in the removePolicy from groups in the target policy Removing a
-   * group that is not found is not an error. If there is nothing left over, return null.
+   * Remove groups - we don't currently have the ability to modify groups, so return the current
+   * policy.
    *
    * @param target existing policy
    * @param removePolicy policy to remove
@@ -60,16 +58,7 @@ public class PolicyGroupConstraint implements PolicyBase {
    */
   @Override
   public PolicyInput remove(PolicyInput target, PolicyInput removePolicy) {
-    Set<String> targetGroups = dataToSet(target.getData(DATA_KEY));
-    Set<String> removeGroups = dataToSet(removePolicy.getData(DATA_KEY));
-    targetGroups.removeAll(removeGroups);
-    if (targetGroups.isEmpty()) {
-      return null;
-    }
-
-    Multimap<String, String> newData = ArrayListMultimap.create();
-    targetGroups.forEach(group -> newData.put(DATA_KEY, group));
-    return new PolicyInput(target.getPolicyName(), newData);
+    return target;
   }
 
   /**

--- a/service/src/main/java/bio/terra/policy/service/policy/PolicyGroupConstraint.java
+++ b/service/src/main/java/bio/terra/policy/service/policy/PolicyGroupConstraint.java
@@ -1,5 +1,6 @@
 package bio.terra.policy.service.policy;
 
+import bio.terra.policy.common.exception.InvalidInputException;
 import bio.terra.policy.common.model.PolicyInput;
 import bio.terra.policy.common.model.PolicyName;
 import com.google.common.annotations.VisibleForTesting;
@@ -49,8 +50,7 @@ public class PolicyGroupConstraint implements PolicyBase {
   }
 
   /**
-   * Remove groups - we don't currently have the ability to modify groups, so return the current
-   * policy.
+   * Remove groups - we don't currently have the ability to modify groups, so throw an exception.
    *
    * @param target existing policy
    * @param removePolicy policy to remove
@@ -58,7 +58,7 @@ public class PolicyGroupConstraint implements PolicyBase {
    */
   @Override
   public PolicyInput remove(PolicyInput target, PolicyInput removePolicy) {
-    return target;
+    throw new InvalidInputException("Cannot remove a group constraint");
   }
 
   /**

--- a/service/src/test/java/bio/terra/policy/controller/TpsBasicControllerTest.java
+++ b/service/src/test/java/bio/terra/policy/controller/TpsBasicControllerTest.java
@@ -20,6 +20,7 @@ public class TpsBasicControllerTest extends TestUnitBase {
   private static final String REGION = "region-name";
   private static final String DDGROUP = "ddgroup";
   private static final String US_REGION = "usa";
+  private static final String IOWA_REGION = "iowa";
 
   @Autowired private MvcUtils mvcUtils;
 
@@ -37,45 +38,53 @@ public class TpsBasicControllerTest extends TestUnitBase {
             .name(REGION_CONSTRAINT)
             .addAdditionalDataItem(new ApiTpsPolicyPair().key(REGION).value(US_REGION));
 
-    var inputs = new ApiTpsPolicyInputs().addInputsItem(groupPolicy).addInputsItem(regionPolicy);
+    var inputs = new ApiTpsPolicyInputs().addInputsItem(groupPolicy);
 
     // Create a PAO
     UUID paoIdA = mvcUtils.createPao(inputs);
 
-    // Create another PAO with no policies
-    UUID paoIdB = mvcUtils.createPao(new ApiTpsPolicyInputs());
+    // Create another PAO with a group policy
+    UUID paoIdB = mvcUtils.createPao(new ApiTpsPolicyInputs().addInputsItem(regionPolicy));
 
     // Get a PAO
     var apiPao = mvcUtils.getPao(paoIdA);
-    checkAttributeSet(apiPao.getAttributes());
-    checkAttributeSet(apiPao.getEffectiveAttributes());
+    checkAttributeSet(apiPao.getAttributes(), US_REGION);
+    checkAttributeSet(apiPao.getEffectiveAttributes(), US_REGION);
 
     // Merge a PAO
     var updateResult = mvcUtils.mergePao(paoIdB, paoIdA);
     assertTrue(updateResult.isUpdateApplied());
     assertEquals(0, updateResult.getConflicts().size());
-    checkAttributeSet(updateResult.getResultingPao().getEffectiveAttributes());
+    checkAttributeSet(updateResult.getResultingPao().getEffectiveAttributes(), US_REGION);
 
     // Link a PAO
     updateResult = mvcUtils.linkPao(paoIdB, paoIdA);
     assertTrue(updateResult.isUpdateApplied());
     assertEquals(0, updateResult.getConflicts().size());
-    checkAttributeSet(updateResult.getResultingPao().getEffectiveAttributes());
+    checkAttributeSet(updateResult.getResultingPao().getEffectiveAttributes(), US_REGION);
+
+    // need to work with region inputs since we can't update groups.
+    var iowaRegionPolicy =
+        new ApiTpsPolicyInput()
+            .namespace(TERRA)
+            .name(REGION_CONSTRAINT)
+            .addAdditionalDataItem(new ApiTpsPolicyPair().key(REGION).value(IOWA_REGION));
+    var iowaInputs = new ApiTpsPolicyInputs().addInputsItem(iowaRegionPolicy);
 
     // Update a PAO
-    updateResult = mvcUtils.updatePao(paoIdB, inputs);
-    checkAttributeSet(updateResult.getResultingPao().getEffectiveAttributes());
+    updateResult = mvcUtils.updatePao(paoIdB, iowaInputs);
+    checkAttributeSet(updateResult.getResultingPao().getEffectiveAttributes(), IOWA_REGION);
 
     // Replace a PAO
-    updateResult = mvcUtils.replacePao(paoIdB, inputs);
-    checkAttributeSet(updateResult.getResultingPao().getEffectiveAttributes());
+    updateResult = mvcUtils.replacePao(paoIdB, iowaInputs);
+    checkAttributeSet(updateResult.getResultingPao().getEffectiveAttributes(), IOWA_REGION);
 
     // Delete a PAO
     mvcUtils.deletePao(paoIdA);
     mvcUtils.deletePao(paoIdB);
   }
 
-  private void checkAttributeSet(ApiTpsPolicyInputs attributeSet) {
+  private void checkAttributeSet(ApiTpsPolicyInputs attributeSet, String expectedRegion) {
     for (ApiTpsPolicyInput attribute : attributeSet.getInputs()) {
       assertEquals(TERRA, attribute.getNamespace());
       assertEquals(1, attribute.getAdditionalData().size());
@@ -85,7 +94,7 @@ public class TpsBasicControllerTest extends TestUnitBase {
         assertEquals(DDGROUP, attribute.getAdditionalData().get(0).getValue());
       } else if (attribute.getName().equals(REGION_CONSTRAINT)) {
         assertEquals(REGION, attribute.getAdditionalData().get(0).getKey());
-        assertEquals(US_REGION, attribute.getAdditionalData().get(0).getValue());
+        assertEquals(expectedRegion, attribute.getAdditionalData().get(0).getValue());
       } else {
         fail();
       }

--- a/service/src/test/java/bio/terra/policy/service/pao/PaoUpdateTest.java
+++ b/service/src/test/java/bio/terra/policy/service/pao/PaoUpdateTest.java
@@ -339,15 +339,15 @@ public class PaoUpdateTest extends TestUnitBase {
         PolicyInput.createFromMap(
             TERRA_NAMESPACE, GROUP_CONSTRAINT, Collections.singletonMap(GROUP_KEY, GROUP_NAME));
 
-    UUID paoId = PaoTestUtil.makePao(paoService, regionPolicy);
-    logger.info("make pao {} with region policy", paoId);
+    UUID paoId = PaoTestUtil.makePao(paoService, groupPolicy);
+    logger.info("make pao {} with a group policy", paoId);
 
-    PolicyInputs groupPolicyInput = PaoTestUtil.makePolicyInputs(groupPolicy);
+    PolicyInputs regionPolicyInput = PaoTestUtil.makePolicyInputs(regionPolicy);
 
     PolicyUpdateResult result =
         paoService.updatePao(
-            paoId, groupPolicyInput, new PolicyInputs(), PaoUpdateMode.FAIL_ON_CONFLICT);
-    logger.info("Update 1 adds a group constraint. Result: {}", result);
+            paoId, regionPolicyInput, new PolicyInputs(), PaoUpdateMode.FAIL_ON_CONFLICT);
+    logger.info("Update 1 adds a region constraint. Result: {}", result);
 
     assertTrue(result.updateApplied());
     assertTrue(result.conflicts().isEmpty());

--- a/service/src/test/java/bio/terra/policy/service/policy/PolicyGroupConstraintTest.java
+++ b/service/src/test/java/bio/terra/policy/service/policy/PolicyGroupConstraintTest.java
@@ -182,7 +182,9 @@ public class PolicyGroupConstraintTest extends TestUnitBase {
     Set<String> groupSet =
         groupConstraint.dataToSet(resultPolicy.getAdditionalData().get(GROUP_KEY));
 
-    assertEquals(2, groupSet.size());
+    // since we can't remove, the result set should match the original set
+    assertEquals(groups.size(), groupSet.size());
+    assertTrue(groupSet.contains(GROUP_NAME));
     assertTrue(groupSet.contains(group2));
     assertTrue(groupSet.contains(group3));
   }

--- a/service/src/test/java/bio/terra/policy/service/policy/PolicyGroupConstraintTest.java
+++ b/service/src/test/java/bio/terra/policy/service/policy/PolicyGroupConstraintTest.java
@@ -12,8 +12,10 @@ import static org.hamcrest.Matchers.contains;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import bio.terra.policy.common.exception.InvalidInputException;
 import bio.terra.policy.common.model.PolicyInput;
 import bio.terra.policy.testutils.TestUnitBase;
 import java.util.Arrays;
@@ -163,7 +165,7 @@ public class PolicyGroupConstraintTest extends TestUnitBase {
   }
 
   @Test
-  void groupConstraintTest_removeGroup() throws Exception {
+  void groupConstraintTest_removeGroupThrows() throws Exception {
     var groupConstraint = new PolicyGroupConstraint();
 
     String group2 = GROUP_NAME + "2";
@@ -178,38 +180,8 @@ public class PolicyGroupConstraintTest extends TestUnitBase {
     var targetPolicy =
         new PolicyInput(TERRA_NAMESPACE, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, groups));
 
-    PolicyInput resultPolicy = groupConstraint.remove(targetPolicy, removePolicy);
-    Set<String> groupSet =
-        groupConstraint.dataToSet(resultPolicy.getAdditionalData().get(GROUP_KEY));
-
-    // since we can't remove, the result set should match the original set
-    assertEquals(groups.size(), groupSet.size());
-    assertTrue(groupSet.contains(GROUP_NAME));
-    assertTrue(groupSet.contains(group2));
-    assertTrue(groupSet.contains(group3));
-  }
-
-  @Test
-  void groupConstraintTest_removeNonExistentGroup() throws Exception {
-    var groupConstraint = new PolicyGroupConstraint();
-
-    var removePolicy =
-        new PolicyInput(TERRA_NAMESPACE, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, GROUP_NAME));
-
-    String group2 = GROUP_NAME + "2";
-    String group3 = GROUP_NAME + "3";
-    Set<String> groups = new HashSet<>(Arrays.asList(group2, group3));
-    var targetPolicy =
-        new PolicyInput(TERRA_NAMESPACE, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, groups));
-
-    // we never added GROUP_NAME into the policy, removing it shouldn't break.
-    PolicyInput resultPolicy = groupConstraint.remove(targetPolicy, removePolicy);
-    Set<String> groupSet =
-        groupConstraint.dataToSet(resultPolicy.getAdditionalData().get(GROUP_KEY));
-
-    assertEquals(2, groupSet.size());
-    assertTrue(groupSet.contains(group2));
-    assertTrue(groupSet.contains(group3));
+    assertThrows(
+        InvalidInputException.class, () -> groupConstraint.remove(targetPolicy, removePolicy));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/policy/service/policy/PolicyGroupConstraintTest.java
+++ b/service/src/test/java/bio/terra/policy/service/policy/PolicyGroupConstraintTest.java
@@ -185,20 +185,6 @@ public class PolicyGroupConstraintTest extends TestUnitBase {
   }
 
   @Test
-  void groupConstraintTest_removeOnlyGroup() throws Exception {
-    var groupConstraint = new PolicyGroupConstraint();
-
-    Set<String> groups = new HashSet<>(Arrays.asList(GROUP_NAME));
-    var removePolicy =
-        new PolicyInput(TERRA_NAMESPACE, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, groups));
-    var targetPolicy =
-        new PolicyInput(TERRA_NAMESPACE, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, groups));
-
-    PolicyInput resultPolicy = groupConstraint.remove(targetPolicy, removePolicy);
-    assertNull(resultPolicy);
-  }
-
-  @Test
   void groupConstraintTest_validation() {
     var groupConstraint = new PolicyGroupConstraint();
 

--- a/service/src/test/java/bio/terra/policy/service/policy/PolicyGroupConstraintTest.java
+++ b/service/src/test/java/bio/terra/policy/service/policy/PolicyGroupConstraintTest.java
@@ -4,6 +4,7 @@ import static bio.terra.policy.service.policy.PolicyTestUtils.*;
 import static bio.terra.policy.testutils.PaoTestUtil.GROUP_CONSTRAINT;
 import static bio.terra.policy.testutils.PaoTestUtil.GROUP_KEY;
 import static bio.terra.policy.testutils.PaoTestUtil.GROUP_NAME;
+import static bio.terra.policy.testutils.PaoTestUtil.GROUP_NAME_ALT;
 import static bio.terra.policy.testutils.PaoTestUtil.REGION_CONSTRAINT;
 import static bio.terra.policy.testutils.PaoTestUtil.REGION_KEY;
 import static bio.terra.policy.testutils.PaoTestUtil.TERRA_NAMESPACE;
@@ -11,7 +12,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -66,7 +66,11 @@ public class PolicyGroupConstraintTest extends TestUnitBase {
         new PolicyInput(TERRA_NAMESPACE, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, GROUP_NAME));
 
     PolicyInput resultPolicy = groupConstraint.combine(null, sourcePolicy);
-    assertNull(resultPolicy);
+    Set<String> groupSet =
+        groupConstraint.dataToSet(resultPolicy.getAdditionalData().get(GROUP_KEY));
+
+    assertEquals(1, groupSet.size());
+    assertTrue(groupSet.containsAll(Arrays.asList(GROUP_NAME)));
   }
 
   @Test
@@ -88,17 +92,21 @@ public class PolicyGroupConstraintTest extends TestUnitBase {
   }
 
   @Test
-  void groupConstraintTest_combineMismatchGroupsFails() throws Exception {
+  void groupConstraintTest_combineMismatchGroups() throws Exception {
     var groupConstraint = new PolicyGroupConstraint();
 
     var dependentPolicy =
         new PolicyInput(TERRA_NAMESPACE, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, GROUP_NAME));
     var sourcePolicy =
         new PolicyInput(
-            TERRA_NAMESPACE, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, GROUP_NAME + "a"));
+            TERRA_NAMESPACE, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, GROUP_NAME_ALT));
 
     PolicyInput resultPolicy = groupConstraint.combine(dependentPolicy, sourcePolicy);
-    assertNull(resultPolicy);
+    Set<String> groupSet =
+        groupConstraint.dataToSet(resultPolicy.getAdditionalData().get(GROUP_KEY));
+
+    assertEquals(2, groupSet.size());
+    assertTrue(groupSet.containsAll(Arrays.asList(GROUP_NAME, GROUP_NAME_ALT)));
   }
 
   @Test
@@ -116,7 +124,6 @@ public class PolicyGroupConstraintTest extends TestUnitBase {
         new PolicyInput(TERRA_NAMESPACE, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, groups));
 
     PolicyInput resultPolicy = groupConstraint.combine(dependentPolicy, sourcePolicy);
-
     Set<String> groupSet =
         groupConstraint.dataToSet(resultPolicy.getAdditionalData().get(GROUP_KEY));
 
@@ -141,7 +148,11 @@ public class PolicyGroupConstraintTest extends TestUnitBase {
         new PolicyInput(TERRA_NAMESPACE, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, groups));
 
     PolicyInput resultPolicy = groupConstraint.combine(dependentPolicy, sourcePolicy);
-    assertNull(resultPolicy);
+    Set<String> groupSet =
+        groupConstraint.dataToSet(resultPolicy.getAdditionalData().get(GROUP_KEY));
+
+    assertEquals(groups.size(), groupSet.size());
+    assertTrue(groupSet.containsAll(groups));
   }
 
   @Test
@@ -161,7 +172,11 @@ public class PolicyGroupConstraintTest extends TestUnitBase {
         new PolicyInput(TERRA_NAMESPACE, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, groups));
 
     PolicyInput resultPolicy = groupConstraint.combine(dependentPolicy, sourcePolicy);
-    assertNull(resultPolicy);
+    Set<String> groupSet =
+        groupConstraint.dataToSet(resultPolicy.getAdditionalData().get(GROUP_KEY));
+
+    assertEquals(3, groupSet.size());
+    assertTrue(groupSet.containsAll(groups));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/policy/testutils/PaoTestUtil.java
+++ b/service/src/test/java/bio/terra/policy/testutils/PaoTestUtil.java
@@ -25,6 +25,7 @@ public class PaoTestUtil {
   public static final String REGION_NAME_EUROPE = "europe";
   public static final String GROUP_KEY = "group";
   public static final String GROUP_NAME = "mygroup";
+  public static final String GROUP_NAME_ALT = "myaltgroup";
 
   public static final String TEST_NAMESPACE = "test_namespace";
   public static final String TEST_FLAG_POLICY_A = "test_flag_a";


### PR DESCRIPTION
We can't update auth domains in SAM during milestone 1. So we shouldn't allow updating the group constraints on a PAO either.

I have a review out for updating the test in WSM for this. That should be completed before we merge this change.