### PR TITLE
PF-2527: Validate known policy types

### DIFF
--- a/service/src/main/java/bio/terra/policy/service/pao/PaoService.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/PaoService.java
@@ -4,6 +4,7 @@ import bio.terra.common.db.WriteTransaction;
 import bio.terra.policy.common.exception.DirectConflictException;
 import bio.terra.policy.common.exception.IllegalCycleException;
 import bio.terra.policy.common.exception.InternalTpsErrorException;
+import bio.terra.policy.common.exception.InvalidInputException;
 import bio.terra.policy.common.exception.PolicyNotImplementedException;
 import bio.terra.policy.common.model.PolicyInput;
 import bio.terra.policy.common.model.PolicyInputs;
@@ -255,6 +256,10 @@ public class PaoService {
 
     // Now integrate the adds into the attribute set
     for (PolicyInput addPolicy : addAttributes.getInputs().values()) {
+      if (!PolicyMutator.validate(addPolicy)) {
+        throw new InvalidInputException(
+            String.format("Invalid PolicyInput: %s", addPolicy.getKey()));
+      }
       PolicyInput existingPolicy = targetPao.getAttributes().lookupPolicy(addPolicy);
       if (existingPolicy == null) {
         // Nothing to combine; just take the new

--- a/service/src/main/java/bio/terra/policy/service/policy/PolicyBase.java
+++ b/service/src/main/java/bio/terra/policy/service/policy/PolicyBase.java
@@ -23,4 +23,12 @@ public interface PolicyBase {
    * @return resulting policy or null if the policy is gone
    */
   PolicyInput remove(PolicyInput target, PolicyInput removePolicy);
+
+  /**
+   * Validate a policy input.
+   *
+   * @param policyInput the input to validate
+   * @return boolean indicating valid or not
+   */
+  boolean isValid(PolicyInput policyInput);
 }

--- a/service/src/main/java/bio/terra/policy/service/policy/PolicyGroupConstraint.java
+++ b/service/src/main/java/bio/terra/policy/service/policy/PolicyGroupConstraint.java
@@ -72,6 +72,23 @@ public class PolicyGroupConstraint implements PolicyBase {
     return new PolicyInput(target.getPolicyName(), newData);
   }
 
+  /**
+   * For groups, the only thing we can validate right now is that the key is correct. TODO: When we
+   * connect TPS to SAM, we can validate the group name as well.
+   *
+   * @param policyInput the input to validate
+   * @return
+   */
+  @Override
+  public boolean isValid(PolicyInput policyInput) {
+    for (var key : policyInput.getAdditionalData().keySet()) {
+      if (!key.equals(DATA_KEY)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   @VisibleForTesting
   Set<String> dataToSet(Collection<String> groups) {
     return new HashSet<>(groups);

--- a/service/src/main/java/bio/terra/policy/service/policy/PolicyMutator.java
+++ b/service/src/main/java/bio/terra/policy/service/policy/PolicyMutator.java
@@ -33,6 +33,11 @@ public class PolicyMutator {
     return findPolicy(removePolicy).remove(target, removePolicy);
   }
 
+  public static boolean validate(PolicyInput policyInput) {
+    PolicyBase policy = findPolicy(policyInput);
+    return policy.isValid(policyInput);
+  }
+
   private static void validateMatchedPolicies(PolicyInput one, PolicyInput two) {
     if (one == null || two == null) {
       // We can still call combine if one of the policies is empty.

--- a/service/src/main/java/bio/terra/policy/service/policy/PolicyRegionConstraint.java
+++ b/service/src/main/java/bio/terra/policy/service/policy/PolicyRegionConstraint.java
@@ -112,6 +112,30 @@ public class PolicyRegionConstraint implements PolicyBase {
     return new PolicyInput(POLICY_NAME, newData);
   }
 
+  /**
+   * Validate that a region policy input has the right key and that the value exists in the
+   * ontology.
+   *
+   * @param policyInput the input to validate
+   * @return
+   */
+  @Override
+  public boolean isValid(PolicyInput policyInput) {
+    Multimap<String, String> additionalData = policyInput.getAdditionalData();
+    for (String key : additionalData.keySet()) {
+      if (!key.equals(DATA_KEY)) {
+        return false;
+      }
+
+      for (var value : additionalData.get(key)) {
+        if (regionService.getLocation(value) == null) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
   @VisibleForTesting
   Set<String> dataToSet(Collection<String> regions) {
     return new HashSet<>(regions);

--- a/service/src/main/java/bio/terra/policy/service/policy/PolicyUnknown.java
+++ b/service/src/main/java/bio/terra/policy/service/policy/PolicyUnknown.java
@@ -70,4 +70,15 @@ public class PolicyUnknown implements PolicyBase {
   public PolicyInput remove(PolicyInput target, PolicyInput removePolicy) {
     return null;
   }
+
+  /**
+   * Unknown policies will be seen as valid.
+   *
+   * @param policyInput the input to validate
+   * @return true
+   */
+  @Override
+  public boolean isValid(PolicyInput policyInput) {
+    return true;
+  }
 }

--- a/service/src/test/java/bio/terra/policy/controller/TpsBasicControllerTest.java
+++ b/service/src/test/java/bio/terra/policy/controller/TpsBasicControllerTest.java
@@ -19,7 +19,7 @@ public class TpsBasicControllerTest extends TestUnitBase {
   private static final String GROUP = "group";
   private static final String REGION = "region-name";
   private static final String DDGROUP = "ddgroup";
-  private static final String US_REGION = "US";
+  private static final String US_REGION = "usa";
 
   @Autowired private MvcUtils mvcUtils;
 

--- a/service/src/test/java/bio/terra/policy/service/policy/PolicyGroupConstraintTest.java
+++ b/service/src/test/java/bio/terra/policy/service/policy/PolicyGroupConstraintTest.java
@@ -10,6 +10,7 @@ import static bio.terra.policy.testutils.PaoTestUtil.TERRA_NAMESPACE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -221,5 +222,26 @@ public class PolicyGroupConstraintTest extends TestUnitBase {
 
     PolicyInput resultPolicy = groupConstraint.remove(targetPolicy, removePolicy);
     assertNull(resultPolicy);
+  }
+
+  @Test
+  void groupConstraintTest_validation() {
+    var groupConstraint = new PolicyGroupConstraint();
+
+    Set<String> groups = new HashSet<>(Arrays.asList(GROUP_NAME));
+    var validPolicy =
+        new PolicyInput(TERRA_NAMESPACE, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, groups));
+    var invalidKey =
+        new PolicyInput(
+            TERRA_NAMESPACE, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY + "invalid", groups));
+
+    groups.add("invalid");
+    var invalidValue =
+        new PolicyInput(TERRA_NAMESPACE, GROUP_CONSTRAINT, buildMultimap(GROUP_KEY, groups));
+
+    assertTrue(groupConstraint.isValid(validPolicy));
+    assertFalse(groupConstraint.isValid(invalidKey));
+    // we don't currently validate the value
+    assertTrue(groupConstraint.isValid(invalidValue));
   }
 }

--- a/service/src/test/java/bio/terra/policy/service/policy/PolicyRegionConstraintTest.java
+++ b/service/src/test/java/bio/terra/policy/service/policy/PolicyRegionConstraintTest.java
@@ -11,7 +11,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.policy.common.model.PolicyInput;
 import bio.terra.policy.testutils.TestUnitBase;
@@ -262,5 +264,31 @@ public class PolicyRegionConstraintTest extends TestUnitBase {
 
     PolicyInput resultPolicy = regionConstraint.remove(targetPolicy, removePolicy);
     assertNull(resultPolicy);
+  }
+
+  @Test
+  void regionConstraintTest_validation() {
+    var regionConstraint = new PolicyRegionConstraint();
+
+    var location1 = "europe";
+
+    var validPolicy =
+        new PolicyInput(TERRA_NAMESPACE, REGION_CONSTRAINT, buildMultimap(REGION_KEY, location1));
+    var validMultiValue =
+        new PolicyInput(
+            TERRA_NAMESPACE,
+            REGION_CONSTRAINT,
+            buildMultimap(REGION_KEY, location1, "usa", "asiapacific"));
+    var invalidKey =
+        new PolicyInput(
+            TERRA_NAMESPACE, REGION_CONSTRAINT, buildMultimap(REGION_KEY + "invalid", location1));
+    var invalidValue =
+        new PolicyInput(
+            TERRA_NAMESPACE, REGION_CONSTRAINT, buildMultimap(REGION_KEY, location1 + "invalid"));
+
+    assertTrue(regionConstraint.isValid(validPolicy));
+    assertTrue(regionConstraint.isValid(validMultiValue));
+    assertFalse(regionConstraint.isValid(invalidKey));
+    assertFalse(regionConstraint.isValid(invalidValue));
   }
 }


### PR DESCRIPTION
Adds validation for additionalData in Region constraints - ensures the keys are valid and the values exist in the ontology.
Also validates the additionalData key for group constraints. We can't validate the value for groups until TPS talks to SAM.