### PR TITLE
PF-2610: Validate policyInputs during PAO Create/Replace

### DIFF
--- a/service/src/main/java/bio/terra/policy/common/model/Constants.java
+++ b/service/src/main/java/bio/terra/policy/common/model/Constants.java
@@ -1,0 +1,5 @@
+package bio.terra.policy.common.model;
+
+public class Constants {
+  public static final String TERRA_NAMESPACE = "terra";
+}

--- a/service/src/main/java/bio/terra/policy/service/pao/PaoService.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/PaoService.java
@@ -67,7 +67,12 @@ public class PaoService {
         component.name(),
         objectType.name());
 
-    // TODO: Validate policy inputs against the policy descriptions when those are available.
+    for (PolicyInput policyInput : inputs.getInputs().values()) {
+      if (!PolicyMutator.validate(policyInput)) {
+        throw new InvalidInputException(
+            String.format("Invalid PolicyInput: %s", policyInput.getKey()));
+      }
+    }
 
     // The DAO does the heavy lifting.
     paoDao.createPao(objectId, component, objectType, inputs);

--- a/service/src/main/java/bio/terra/policy/service/pao/PaoService.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/PaoService.java
@@ -66,14 +66,7 @@ public class PaoService {
         objectId,
         component.name(),
         objectType.name());
-
-    for (PolicyInput policyInput : inputs.getInputs().values()) {
-      if (!PolicyMutator.validate(policyInput)) {
-        throw new InvalidInputException(
-            String.format("Invalid PolicyInput: %s", policyInput.getKey()));
-      }
-    }
-
+    validatePolicyInputs(inputs);
     // The DAO does the heavy lifting.
     paoDao.createPao(objectId, component, objectType, inputs);
   }
@@ -216,7 +209,7 @@ public class PaoService {
         targetPaoId,
         replacementAttributes,
         updateMode);
-
+    validatePolicyInputs(replacementAttributes);
     Pao targetPao = paoDao.getPao(targetPaoId);
     return updateAttributesWorker(replacementAttributes, targetPao, updateMode);
   }
@@ -343,5 +336,14 @@ public class PaoService {
     }
 
     return conflicts;
+  }
+
+  private void validatePolicyInputs(PolicyInputs inputs) {
+    for (PolicyInput policyInput : inputs.getInputs().values()) {
+      if (!PolicyMutator.validate(policyInput)) {
+        throw new InvalidInputException(
+            String.format("Invalid PolicyInput: %s", policyInput.getKey()));
+      }
+    }
   }
 }

--- a/service/src/main/java/bio/terra/policy/service/policy/PolicyMutator.java
+++ b/service/src/main/java/bio/terra/policy/service/policy/PolicyMutator.java
@@ -1,5 +1,7 @@
 package bio.terra.policy.service.policy;
 
+import static bio.terra.policy.common.model.Constants.TERRA_NAMESPACE;
+
 import bio.terra.policy.common.exception.InternalTpsErrorException;
 import bio.terra.policy.common.model.PolicyInput;
 import java.util.Map;
@@ -34,8 +36,12 @@ public class PolicyMutator {
   }
 
   public static boolean validate(PolicyInput policyInput) {
-    PolicyBase policy = findPolicy(policyInput);
-    return policy.isValid(policyInput);
+    if (policyInput.getPolicyName().getNamespace().equals(TERRA_NAMESPACE)) {
+      PolicyBase policy = findPolicy(policyInput);
+      return policy.isValid(policyInput);
+    }
+
+    return true;
   }
 
   private static void validateMatchedPolicies(PolicyInput one, PolicyInput two) {

--- a/service/src/main/java/bio/terra/policy/service/policy/PolicyUnknown.java
+++ b/service/src/main/java/bio/terra/policy/service/policy/PolicyUnknown.java
@@ -72,13 +72,13 @@ public class PolicyUnknown implements PolicyBase {
   }
 
   /**
-   * Unknown policies will be seen as invalid.
+   * Unknown policies will be seen as valid.
    *
    * @param policyInput the input to validate
-   * @return false
+   * @return true
    */
   @Override
   public boolean isValid(PolicyInput policyInput) {
-    return false;
+    return true;
   }
 }

--- a/service/src/test/java/bio/terra/policy/service/pao/PaoDeleteTest.java
+++ b/service/src/test/java/bio/terra/policy/service/pao/PaoDeleteTest.java
@@ -27,7 +27,7 @@ public class PaoDeleteTest extends TestUnitBase {
   private static final String GROUP = "group";
   private static final String REGION = "region-name";
   private static final String DDGROUP = "ddgroup";
-  private static final String US_REGION = "US";
+  private static final String US_REGION = "usa";
 
   @Autowired private PaoService paoService;
 

--- a/service/src/test/java/bio/terra/policy/service/pao/PaoMergeTest.java
+++ b/service/src/test/java/bio/terra/policy/service/pao/PaoMergeTest.java
@@ -23,9 +23,7 @@ public class PaoMergeTest extends TestUnitBase {
   void mergeSourceToEmptyDestination() {
     UUID paoSourceId =
         PaoTestUtil.makePao(
-            paoService,
-            PaoTestUtil.makeFlagInput(PaoTestUtil.TEST_FLAG_POLICY_A),
-            PaoTestUtil.makeDataInput(PaoTestUtil.TEST_DATA_POLICY_X, PaoTestUtil.DATA1));
+            paoService, PaoTestUtil.makeRegionPolicyInput(PaoTestUtil.REGION_NAME_USA));
     logger.info("paoSourceId: {}", paoSourceId);
 
     UUID paoDestinationId = PaoTestUtil.makePao(paoService);
@@ -38,9 +36,7 @@ public class PaoMergeTest extends TestUnitBase {
     assertTrue(result.conflicts().isEmpty());
     Pao resultPao = result.computedPao();
     PaoTestUtil.checkForPolicies(
-        resultPao,
-        PaoTestUtil.makeFlagInput(PaoTestUtil.TEST_FLAG_POLICY_A),
-        PaoTestUtil.makeDataInput(PaoTestUtil.TEST_DATA_POLICY_X, PaoTestUtil.DATA1));
+        resultPao, PaoTestUtil.makeRegionPolicyInput(PaoTestUtil.REGION_NAME_USA));
   }
 
   @Test
@@ -48,17 +44,13 @@ public class PaoMergeTest extends TestUnitBase {
     // PaoA - has flag A and data policy X, data1
     UUID paoAid =
         PaoTestUtil.makePao(
-            paoService,
-            PaoTestUtil.makeFlagInput(PaoTestUtil.TEST_FLAG_POLICY_A),
-            PaoTestUtil.makeDataInput(PaoTestUtil.TEST_DATA_POLICY_X, PaoTestUtil.DATA1));
+            paoService, PaoTestUtil.makeRegionPolicyInput(PaoTestUtil.REGION_NAME_USA));
     logger.info("paoAid: {}", paoAid);
 
     // PaoB - has flag B and data policy X, data1
     UUID paoBid =
         PaoTestUtil.makePao(
-            paoService,
-            PaoTestUtil.makeFlagInput(PaoTestUtil.TEST_FLAG_POLICY_B),
-            PaoTestUtil.makeDataInput(PaoTestUtil.TEST_DATA_POLICY_X, PaoTestUtil.DATA1));
+            paoService, PaoTestUtil.makeRegionPolicyInput(PaoTestUtil.REGION_NAME_IOWA));
     logger.info("paoBid: {}", paoBid);
 
     // merge A into B
@@ -68,10 +60,7 @@ public class PaoMergeTest extends TestUnitBase {
     assertTrue(result.conflicts().isEmpty());
     Pao resultPao = result.computedPao();
     PaoTestUtil.checkForPolicies(
-        resultPao,
-        PaoTestUtil.makeFlagInput(PaoTestUtil.TEST_FLAG_POLICY_A),
-        PaoTestUtil.makeFlagInput(PaoTestUtil.TEST_FLAG_POLICY_B),
-        PaoTestUtil.makeDataInput(PaoTestUtil.TEST_DATA_POLICY_X, PaoTestUtil.DATA1));
+        resultPao, PaoTestUtil.makeRegionPolicyInput(PaoTestUtil.REGION_NAME_IOWA));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/policy/service/pao/PaoReplaceTest.java
+++ b/service/src/test/java/bio/terra/policy/service/pao/PaoReplaceTest.java
@@ -63,8 +63,8 @@ public class PaoReplaceTest extends TestUnitBase {
     UUID paoAid =
         PaoTestUtil.makePao(
             paoService,
-            PaoTestUtil.makeFlagInput(PaoTestUtil.TEST_FLAG_POLICY_A),
-            PaoTestUtil.makeDataInput(PaoTestUtil.TEST_DATA_POLICY_X, PaoTestUtil.DATA1));
+            PaoTestUtil.makeRegionPolicyInput(PaoTestUtil.REGION_NAME_USA),
+            PaoTestUtil.makeGroupPolicyInput(PaoTestUtil.GROUP_NAME));
     logger.info("paoAid: {}", paoAid);
 
     // PaoB - starts empty
@@ -80,20 +80,19 @@ public class PaoReplaceTest extends TestUnitBase {
     Pao resultPao = result.computedPao();
     PaoTestUtil.checkForPolicies(
         resultPao,
-        PaoTestUtil.makeFlagInput(PaoTestUtil.TEST_FLAG_POLICY_A),
-        PaoTestUtil.makeDataInput(PaoTestUtil.TEST_DATA_POLICY_X, PaoTestUtil.DATA1));
+        PaoTestUtil.makeRegionPolicyInput(PaoTestUtil.REGION_NAME_USA),
+        PaoTestUtil.makeGroupPolicyInput(PaoTestUtil.GROUP_NAME));
 
     // Try a conflicting replace on A
     var newAttributes =
         PaoTestUtil.makePolicyInputs(
-            PaoTestUtil.makeFlagInput(PaoTestUtil.TEST_FLAG_POLICY_B),
-            PaoTestUtil.makeDataInput(PaoTestUtil.TEST_DATA_POLICY_X, PaoTestUtil.DATA2));
+            PaoTestUtil.makeRegionPolicyInput(PaoTestUtil.REGION_NAME_EUROPE));
     result = paoService.replacePao(paoBid, newAttributes, PaoUpdateMode.FAIL_ON_CONFLICT);
     assertFalse(result.updateApplied());
     PaoTestUtil.checkConflict(
         result,
         paoBid,
         paoBid,
-        new PolicyName(PaoTestUtil.TEST_NAMESPACE, PaoTestUtil.TEST_DATA_POLICY_X));
+        new PolicyName(PaoTestUtil.TERRA_NAMESPACE, PaoTestUtil.REGION_CONSTRAINT));
   }
 }

--- a/service/src/test/java/bio/terra/policy/service/pao/PaoReplaceTest.java
+++ b/service/src/test/java/bio/terra/policy/service/pao/PaoReplaceTest.java
@@ -27,8 +27,8 @@ public class PaoReplaceTest extends TestUnitBase {
 
     var newAttributes =
         PaoTestUtil.makePolicyInputs(
-            PaoTestUtil.makeFlagInput(PaoTestUtil.TEST_FLAG_POLICY_A),
-            PaoTestUtil.makeDataInput(PaoTestUtil.TEST_DATA_POLICY_X, PaoTestUtil.DATA1));
+            PaoTestUtil.makeRegionPolicyInput(PaoTestUtil.REGION_NAME_USA),
+            PaoTestUtil.makeGroupPolicyInput(PaoTestUtil.GROUP_NAME));
 
     PolicyUpdateResult result =
         paoService.replacePao(paoId, newAttributes, PaoUpdateMode.FAIL_ON_CONFLICT);
@@ -38,13 +38,13 @@ public class PaoReplaceTest extends TestUnitBase {
     Pao resultPao = result.computedPao();
     PaoTestUtil.checkForPolicies(
         resultPao,
-        PaoTestUtil.makeFlagInput(PaoTestUtil.TEST_FLAG_POLICY_A),
-        PaoTestUtil.makeDataInput(PaoTestUtil.TEST_DATA_POLICY_X, PaoTestUtil.DATA1));
+        PaoTestUtil.makeRegionPolicyInput(PaoTestUtil.REGION_NAME_USA),
+        PaoTestUtil.makeGroupPolicyInput(PaoTestUtil.GROUP_NAME));
 
     var moreNewAttributes =
         PaoTestUtil.makePolicyInputs(
-            PaoTestUtil.makeFlagInput(PaoTestUtil.TEST_FLAG_POLICY_B),
-            PaoTestUtil.makeDataInput(PaoTestUtil.TEST_DATA_POLICY_X, PaoTestUtil.DATA2));
+            PaoTestUtil.makeRegionPolicyInput(PaoTestUtil.REGION_NAME_EUROPE),
+            PaoTestUtil.makeGroupPolicyInput(PaoTestUtil.GROUP_NAME_ALT));
 
     result = paoService.replacePao(paoId, moreNewAttributes, PaoUpdateMode.FAIL_ON_CONFLICT);
     logger.info("replace2 result: {}", result);
@@ -53,8 +53,8 @@ public class PaoReplaceTest extends TestUnitBase {
     resultPao = result.computedPao();
     PaoTestUtil.checkForPolicies(
         resultPao,
-        PaoTestUtil.makeFlagInput(PaoTestUtil.TEST_FLAG_POLICY_B),
-        PaoTestUtil.makeDataInput(PaoTestUtil.TEST_DATA_POLICY_X, PaoTestUtil.DATA2));
+        PaoTestUtil.makeRegionPolicyInput(PaoTestUtil.REGION_NAME_EUROPE),
+        PaoTestUtil.makeGroupPolicyInput(PaoTestUtil.GROUP_NAME_ALT));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/policy/service/pao/PaoServiceTest.java
+++ b/service/src/test/java/bio/terra/policy/service/pao/PaoServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import bio.terra.policy.common.exception.InvalidInputException;
 import bio.terra.policy.common.exception.PolicyObjectNotFoundException;
 import bio.terra.policy.common.model.PolicyInput;
 import bio.terra.policy.common.model.PolicyInputs;
@@ -59,6 +60,33 @@ public class PaoServiceTest extends TestUnitBase {
     paoService.deletePao(objectId);
 
     assertThrows(PolicyObjectNotFoundException.class, () -> paoService.getPao(objectId));
+  }
+
+  @Test
+  void createPaoTest_invalidInputThrows() throws Exception {
+    var objectId = UUID.randomUUID();
+
+    var invalidGroupPolicy =
+        PolicyInput.createFromMap(
+            TERRA, GROUP_CONSTRAINT, Collections.singletonMap("badkey", DDGROUP));
+    var invalidRegionPolicy =
+        PolicyInput.createFromMap(
+            TERRA, REGION_CONSTRAINT, Collections.singletonMap(REGION, "badregion"));
+
+    var groupInputs = new PolicyInputs();
+    groupInputs.addInput(invalidGroupPolicy);
+    assertThrows(
+        InvalidInputException.class,
+        () ->
+            paoService.createPao(objectId, PaoComponent.WSM, PaoObjectType.WORKSPACE, groupInputs));
+
+    var regionInputs = new PolicyInputs();
+    regionInputs.addInput(invalidRegionPolicy);
+    assertThrows(
+        InvalidInputException.class,
+        () ->
+            paoService.createPao(
+                objectId, PaoComponent.WSM, PaoObjectType.WORKSPACE, regionInputs));
   }
 
   private void checkAttributeSet(

--- a/service/src/test/java/bio/terra/policy/service/pao/PaoServiceTest.java
+++ b/service/src/test/java/bio/terra/policy/service/pao/PaoServiceTest.java
@@ -24,9 +24,9 @@ public class PaoServiceTest extends TestUnitBase {
   private static final String GROUP_CONSTRAINT = "group-constraint";
   private static final String REGION_CONSTRAINT = "region-constraint";
   private static final String GROUP = "group";
-  private static final String REGION = "region";
+  private static final String REGION = "region-name";
   private static final String DDGROUP = "ddgroup";
-  private static final String US_REGION = "US";
+  private static final String US_REGION = "usa";
 
   @Autowired private PaoService paoService;
 

--- a/service/src/test/java/bio/terra/policy/testutils/PaoTestUtil.java
+++ b/service/src/test/java/bio/terra/policy/testutils/PaoTestUtil.java
@@ -22,6 +22,7 @@ public class PaoTestUtil {
   public static final String GROUP_CONSTRAINT = "group-constraint";
   public static final String REGION_KEY = "region-name";
   public static final String REGION_NAME_USA = "usa";
+  public static final String REGION_NAME_IOWA = "iowa";
   public static final String REGION_NAME_EUROPE = "europe";
   public static final String GROUP_KEY = "group";
   public static final String GROUP_NAME = "mygroup";


### PR DESCRIPTION
We had validation while updating & merging policies, but not during initial create or replace. We should validate those too.