### PR TITLE
[PF-2234] Add created and lastUpdated to policy objects

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -633,6 +633,15 @@ components:
         deleted:
           description: Policy source has been deleted. Policies from the source still apply.
           type: boolean
+        createdDate:
+          description: Timestamp when the policy object was created; ISO 8601 full-date format
+          type: string
+        lastUpdatedDate:
+          description: |
+            Timestamp where the policy was last updated. Updates may be direct changes
+            to this policy object or indirect changes coming from source policy objects.
+            ISO 8601 full-date format
+          type: string
 
     TpsPaoGetResult:
       type: object
@@ -655,6 +664,15 @@ components:
           uniqueItems: true
           items:
             $ref: '#/components/schemas/TpsObjectId'
+        createdDate:
+          description: Timestamp when the policy object was created; ISO 8601 full-date format
+          type: string
+        lastUpdatedDate:
+          description: |
+            Timestamp where the policy was last updated. Updates may be direct changes
+            to this policy object or indirect changes coming from source policy objects.
+            ISO 8601 full-date format
+          type: string
 
     TpsPolicyInputs:
       type: object

--- a/service/src/main/java/bio/terra/policy/app/controller/ConversionUtils.java
+++ b/service/src/main/java/bio/terra/policy/app/controller/ConversionUtils.java
@@ -93,7 +93,9 @@ public class ConversionUtils {
         .attributes(policyInputsToApi(pao.getAttributes()))
         .effectiveAttributes(policyInputsToApi(pao.getEffectiveAttributes()))
         .sourcesObjectIds(pao.getSourceObjectIds().stream().toList())
-        .deleted((pao.getDeleted()));
+        .deleted(pao.getDeleted())
+        .createdDate(pao.getCreated().toString())
+        .lastUpdatedDate(pao.getLastUpdated().toString());
   }
 
   static ApiTpsLocation regionToApi(Location location) {

--- a/service/src/main/java/bio/terra/policy/app/controller/TpsApiController.java
+++ b/service/src/main/java/bio/terra/policy/app/controller/TpsApiController.java
@@ -45,9 +45,6 @@ public class TpsApiController implements TpsApi {
     this.regionService = regionService;
   }
 
-  // -- Policy Queries --
-  // TODO: PF-1733 Next step is to add group membership constraint
-
   // -- Policy Attribute Objects --
   @Override
   public ResponseEntity<Void> createPao(ApiTpsPaoCreateRequest body) {
@@ -79,7 +76,9 @@ public class TpsApiController implements TpsApi {
                         .component(ep.getComponent().toApi())
                         .objectType(ep.getObjectType().toApi())
                         .objectId(ep.getObjectId())
-                        .deleted(ep.getDeleted()))
+                        .deleted(ep.getDeleted())
+                        .createdDate(ep.getCreated().toString())
+                        .lastUpdatedDate(ep.getLastUpdated().toString()))
             .toList();
 
     // Convert the explanations to API form

--- a/service/src/main/java/bio/terra/policy/db/DbPao.java
+++ b/service/src/main/java/bio/terra/policy/db/DbPao.java
@@ -2,6 +2,7 @@ package bio.terra.policy.db;
 
 import bio.terra.policy.service.pao.model.PaoComponent;
 import bio.terra.policy.service.pao.model.PaoObjectType;
+import java.time.Instant;
 import java.util.Set;
 import java.util.UUID;
 
@@ -13,4 +14,6 @@ public record DbPao(
     Set<String> sources,
     String attributeSetId,
     String effectiveSetId,
-    boolean deleted) {}
+    boolean deleted,
+    Instant created,
+    Instant lastUpdated) {}

--- a/service/src/main/java/bio/terra/policy/service/pao/PaoService.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/PaoService.java
@@ -5,7 +5,6 @@ import bio.terra.policy.common.exception.DirectConflictException;
 import bio.terra.policy.common.exception.IllegalCycleException;
 import bio.terra.policy.common.exception.InternalTpsErrorException;
 import bio.terra.policy.common.exception.InvalidInputException;
-import bio.terra.policy.common.exception.PolicyNotImplementedException;
 import bio.terra.policy.common.model.PolicyInput;
 import bio.terra.policy.common.model.PolicyInputs;
 import bio.terra.policy.db.DbPao;
@@ -44,10 +43,6 @@ public class PaoService {
   @Autowired
   public PaoService(PaoDao paoDao) {
     this.paoDao = paoDao;
-  }
-
-  public void clonePao(UUID sourceObjectId, UUID destinationObjectId) {
-    throw new PolicyNotImplementedException("Deprecated method. Here until we change the WSM call");
   }
 
   /**

--- a/service/src/main/java/bio/terra/policy/service/pao/model/Pao.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/model/Pao.java
@@ -2,6 +2,7 @@ package bio.terra.policy.service.pao.model;
 
 import bio.terra.policy.common.model.PolicyInputs;
 import bio.terra.policy.db.DbPao;
+import java.time.Instant;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -17,6 +18,8 @@ public class Pao {
   private PolicyInputs effectiveAttributes;
   private Set<UUID> sourceObjectIds;
   private boolean deleted;
+  private Instant created;
+  private Instant lastUpdated;
 
   public Pao(
       UUID objectId,
@@ -25,7 +28,9 @@ public class Pao {
       PolicyInputs attributes,
       PolicyInputs effectiveAttributes,
       Set<UUID> sourceObjectIds,
-      boolean deleted) {
+      boolean deleted,
+      Instant created,
+      Instant lastUpdated) {
     this.objectId = objectId;
     this.component = component;
     this.objectType = objectType;
@@ -33,6 +38,8 @@ public class Pao {
     this.effectiveAttributes = effectiveAttributes;
     this.sourceObjectIds = sourceObjectIds;
     this.deleted = deleted;
+    this.created = created;
+    this.lastUpdated = lastUpdated;
   }
 
   public UUID getObjectId() {
@@ -67,16 +74,20 @@ public class Pao {
     return sourceObjectIds;
   }
 
-  public void setSourceObjectIds(Set<UUID> sourceObjectIds) {
-    this.sourceObjectIds = sourceObjectIds;
-  }
-
   public boolean getDeleted() {
     return deleted;
   }
 
   public void setDeleted(boolean deleted) {
     this.deleted = deleted;
+  }
+
+  public Instant getCreated() {
+    return created;
+  }
+
+  public Instant getLastUpdated() {
+    return lastUpdated;
   }
 
   public String toShortString() {
@@ -93,6 +104,8 @@ public class Pao {
         .add("effectiveAttributes=" + effectiveAttributes)
         .add("sourceObjectIds=" + sourceObjectIds)
         .add("deleted=" + deleted)
+        .add("created=" + created)
+        .add("lastUpdated=" + lastUpdated)
         .toString();
   }
 
@@ -106,6 +119,8 @@ public class Pao {
         .setAttributes(attributeSetMap.get(dbPao.attributeSetId()))
         .setEffectiveAttributes(attributeSetMap.get(dbPao.effectiveSetId()))
         .setDeleted(dbPao.deleted())
+        .setCreated(dbPao.created())
+        .setLastUpdated(dbPao.lastUpdated())
         .build();
   }
 
@@ -117,6 +132,8 @@ public class Pao {
     private PolicyInputs effectiveAttributes;
     private Set<UUID> sourceObjectIds;
     private boolean deleted;
+    private Instant created;
+    private Instant lastUpdated;
 
     public Builder setObjectId(UUID objectId) {
       this.objectId = objectId;
@@ -153,6 +170,16 @@ public class Pao {
       return this;
     }
 
+    public Builder setCreated(Instant created) {
+      this.created = created;
+      return this;
+    }
+
+    public Builder setLastUpdated(Instant lastUpdated) {
+      this.lastUpdated = lastUpdated;
+      return this;
+    }
+
     public Pao build() {
       if (sourceObjectIds == null) {
         sourceObjectIds = new HashSet<>();
@@ -164,7 +191,9 @@ public class Pao {
           attributes,
           effectiveAttributes,
           sourceObjectIds,
-          deleted);
+          deleted,
+          created,
+          lastUpdated);
     }
   }
 }

--- a/service/src/main/resources/policydb/changelog.xml
+++ b/service/src/main/resources/policydb/changelog.xml
@@ -8,4 +8,5 @@
   <include file="changesets/20220812_pao_features.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20220909_remove_predecessor.yaml" relativeToChangelogFile="true"/>
   <include file="changesets/20220830_pao_deleted.yaml" relativeToChangelogFile="true"/>
+  <include file="changesets/20230405_dates.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/service/src/main/resources/policydb/changesets/20230405_dates.yaml
+++ b/service/src/main/resources/policydb/changesets/20230405_dates.yaml
@@ -1,0 +1,16 @@
+databaseChangeLog:
+  - changeSet:
+      id: remove policy description table and add dates to
+      author: dd
+      changes:
+      - dropTable:
+          tableName: policy_attribute
+      - addColumn:
+          tableName: policy_object
+          columns:
+              - column:
+                  name: created
+                  type: timestamptz
+              - column:
+                  name: last_updated
+                  type: timestamptz

--- a/service/src/main/resources/policydb/changesets/20230405_dates.yaml
+++ b/service/src/main/resources/policydb/changesets/20230405_dates.yaml
@@ -1,6 +1,6 @@
 databaseChangeLog:
   - changeSet:
-      id: remove policy description table and add dates to
+      id: remove policy description table and add dates to policy_object table
       author: dd
       changes:
       - dropTable:

--- a/service/src/test/java/bio/terra/policy/controller/TpsBasicControllerTest.java
+++ b/service/src/test/java/bio/terra/policy/controller/TpsBasicControllerTest.java
@@ -84,7 +84,6 @@ public class TpsBasicControllerTest extends TestUnitBase {
     // Replace a PAO
     updateResult = mvcUtils.replacePao(paoIdB, iowaInputs);
     checkAttributeSet(updateResult.getResultingPao().getEffectiveAttributes(), IOWA_REGION);
-    dumpDates(paoIdA, paoIdB);
     checkLastUpdateChanged(lastUpdatedB, paoIdB);
 
     // Delete a PAO
@@ -121,14 +120,5 @@ public class TpsBasicControllerTest extends TestUnitBase {
     var apiPao = mvcUtils.getPao(paoId);
     assertNotEquals(lastUpdated, apiPao.getLastUpdatedDate());
     return apiPao.getLastUpdatedDate();
-  }
-
-  private void dumpDates(UUID paoIdA, UUID paoIdB) throws Exception {
-    var paoA = mvcUtils.getPao(paoIdA);
-    var paoB = mvcUtils.getPao(paoIdB);
-    System.out.println("PAO-A");
-    System.out.print(paoA);
-    System.out.println("PAO-B");
-    System.out.print(paoB);
   }
 }

--- a/service/src/test/java/bio/terra/policy/controller/TpsExplainControllerTest.java
+++ b/service/src/test/java/bio/terra/policy/controller/TpsExplainControllerTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -11,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import bio.terra.policy.generated.model.ApiTpsComponent;
 import bio.terra.policy.generated.model.ApiTpsObjectType;
 import bio.terra.policy.generated.model.ApiTpsPaoExplainResult;
+import bio.terra.policy.generated.model.ApiTpsPaoGetResult;
 import bio.terra.policy.generated.model.ApiTpsPaoUpdateResult;
 import bio.terra.policy.generated.model.ApiTpsPolicyExplainSource;
 import bio.terra.policy.generated.model.ApiTpsPolicyExplanation;
@@ -179,9 +181,23 @@ public class TpsExplainControllerTest extends TestUnitBase {
     UUID threePao = mvcUtils.createPao(YU_POLICY_INPUT);
     UUID fourPao = mvcUtils.createPao(MC_POLICY_INPUT);
 
-    // Connect top to one and two
+    // Connect top to one and two; validate dates
+    ApiTpsPaoGetResult topPaoData = mvcUtils.getPao(topPao);
+    ApiTpsPaoGetResult onePaoData = mvcUtils.getPao(onePao);
+    assertEquals(topPaoData.getCreatedDate(), topPaoData.getLastUpdatedDate());
+    assertEquals(onePaoData.getCreatedDate(), onePaoData.getLastUpdatedDate());
+
     ApiTpsPaoUpdateResult linkResult = mvcUtils.linkPao(topPao, onePao);
     assertTrue(linkResult.isUpdateApplied());
+
+    ApiTpsPaoGetResult topPaoUpdatedData = mvcUtils.getPao(topPao);
+    ApiTpsPaoGetResult onePaoUpdatedData = mvcUtils.getPao(onePao);
+    // Created data should not change
+    assertEquals(topPaoUpdatedData.getCreatedDate(), topPaoData.getCreatedDate());
+    assertEquals(onePaoUpdatedData.getCreatedDate(), onePaoData.getCreatedDate());
+    // Last updated date should change on the link dependent
+    assertNotEquals(topPaoUpdatedData.getCreatedDate(), topPaoUpdatedData.getLastUpdatedDate());
+
     linkResult = mvcUtils.linkPao(topPao, twoPao);
     assertTrue(linkResult.isUpdateApplied());
 


### PR DESCRIPTION
Add created and lastUpdated to
- OpenAPI
- database schema
- DAO
- PAO model
- Conversion of PAO to OpenAPI

Added checks in two tests to validate update changes.
