### PR TITLE
PF-2685: Add AWS platform to Swagger spec.

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -423,11 +423,11 @@ components:
     Platform:
       name: platform
       in: query
-      description: The cloud platform (gcp, azure)
+      description: The cloud platform (gcp, azure, aws)
       required: true
       schema:
         type: string
-        enum: ["gcp", "azure"]
+        enum: ["gcp", "azure", "aws"]
 
     Location:
       name: location


### PR DESCRIPTION
Missed the Swagger API spec in [my last PR](https://github.com/DataBiosphere/terra-policy-service/pull/61).