### PR TITLE
[ID-630] upgrade snakeyaml in buildsrc

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -19,4 +19,5 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.1.1'
     // This is required due to a dependency conflict between jib and srcclr. Removing it will cause jib to fail.
     implementation 'org.apache.commons:commons-compress:1.21'
+    implementation 'org.yaml:snakeyaml:2.0'
 }

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -37,7 +37,6 @@ dependencies {
         exclude group: 'org.springframework.boot'
         exclude group: 'org.yaml', module: 'snakeyaml'
     }
-    implementation 'org.yaml:snakeyaml:2.0'
 
     implementation 'org.apache.commons:commons-dbcp2:2.9.0'
     implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'


### PR DESCRIPTION
snakeyaml 1.33 was still getting pulled in, moving the dependency declaration to the buildSrc gradle file looks like it will fix it 