### PR TITLE
[PF-2903] Add gcp prefix to EU and US multiregions

### DIFF
--- a/service/src/main/resources/static/locations.yml
+++ b/service/src/main/resources/static/locations.yml
@@ -112,7 +112,7 @@ locations:
       cloudRegion: norwayeast
       cloudPlatform: azure
       description: Norway East (Azure)
-  - name: multiregion-eu
+  - name: gcp.multiregion-eu
     description: Multi-Region EU (GCP)
     cloudRegion: EU
     cloudPlatform: gcp
@@ -213,7 +213,7 @@ locations:
         description: US East (N. Virginia)
         cloudRegion: us-east-1
         cloudPlatform: aws
-    - name: multiregion-us
+    - name: gcp.multiregion-us
       description: Multi-region US
       cloudRegion: US
       cloudPlatform: gcp


### PR DESCRIPTION
Currently, the names of all individual GCP regions in the location ontology are prefixed with gcp-. However, the US and EU multiregions are not. We should fix these, both for consistency and because these prefixes are currently the most reliable way for API callers to determine the cloud platform of a particular region. These regions already have the `cloudPlatform` field set to `gcp`.

According to a Github search of DataBiosphere and BroadInstitute orgs, these locations are both currently unused.