### PR TITLE
remove duplciated asia-southeast2

### DIFF
--- a/service/src/main/resources/static/locations.yml
+++ b/service/src/main/resources/static/locations.yml
@@ -357,13 +357,6 @@ locations:
       cloudRegion: southeastasia
       cloudPlatform: azure
       description: Southeast Asia (Azure)
-  - name: indonesia
-    description: Indonesia
-    locations:
-    - name: gcp.asia-southeast2
-      description: Asia Southeast 2 (GCP)
-      cloudRegion: asia-southeast2
-      cloudPlatform: gcp
   - name: taiwan
     description: Taiwan
     locations:


### PR DESCRIPTION
Shows up in the same file ~50 lines above. Causes the region to be returned twice in the API call.