### PR TITLE
[PF-2907] Match GCP multiregion names

### DIFF
--- a/service/src/main/resources/static/locations.yml
+++ b/service/src/main/resources/static/locations.yml
@@ -112,7 +112,7 @@ locations:
       cloudRegion: norwayeast
       cloudPlatform: azure
       description: Norway East (Azure)
-  - name: gcp.multiregion-eu
+  - name: gcp.EU
     description: Multi-Region EU (GCP)
     cloudRegion: EU
     cloudPlatform: gcp
@@ -213,7 +213,7 @@ locations:
         description: US East (N. Virginia)
         cloudRegion: us-east-1
         cloudPlatform: aws
-    - name: gcp.multiregion-us
+    - name: gcp.US
       description: Multi-region US
       cloudRegion: US
       cloudPlatform: gcp


### PR DESCRIPTION
Verily's UI currently reads the region from the `name` field of the region ontology for regions prefixed with `gcp`, as `cloudPlatform` isn't available from the API.  We should fix this API, but in the mean time the multi-region locations should match GCP's values.