### PR TITLE
[PF-2972] Update dependencies with known vulnerabilities

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     implementation 'io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.0.11.RELEASE'
     implementation 'org.hidetake.swagger.generator:org.hidetake.swagger.generator.gradle.plugin:2.19.1'
     implementation 'org.sonarqube:org.sonarqube.gradle.plugin:3.4.0.2513'
-    implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.1.1'
+    implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.1.3'
     // This is required due to a dependency conflict between jib and srcclr. Removing it will cause jib to fail.
     implementation 'org.apache.commons:commons-compress:1.21'
     implementation 'org.yaml:snakeyaml:2.0'

--- a/buildSrc/src/main/groovy/bio.terra.policy.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.policy.java-common-conventions.gradle
@@ -79,9 +79,16 @@ compileJava {
 
 // Spotbugs configuration
 spotbugs {
-    toolVersion = '4.7.0'
+    toolVersion = '4.7.3'
     reportLevel = 'high'
     effort = 'max'
+}
+// The latest version of spotbugs still pulls in a vulnerable dependency.
+// This can be removed when a new spotbugs version is available.
+dependencies {
+    constraints {
+        spotbugs 'org.apache.bcel:bcel:6.6.1'
+    }
 }
 spotbugsMain {
     reports {

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -23,7 +23,7 @@ dependencyManagement {
     }
 }
 
-def springBootVersion = '3.1.1'
+def springBootVersion = '3.1.3'
 
 dependencies {
 
@@ -46,7 +46,6 @@ dependencies {
     implementation 'org.apache.commons:commons-dbcp2:2.9.0'
     implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'
     implementation 'org.postgresql:postgresql:42.6.0'
-    implementation 'javax.servlet:jstl:1.2'
 
     implementation "org.springframework.boot:spring-boot-starter-data-jdbc:$springBootVersion"
     implementation "org.springframework.boot:spring-boot-starter-web:$springBootVersion"
@@ -57,7 +56,7 @@ dependencies {
 
     implementation 'org.apache.commons:commons-lang3:3.0'
 
-    liquibaseRuntime 'org.liquibase:liquibase-core:3.10.0'
+    liquibaseRuntime 'org.liquibase:liquibase-core:4.20.0'
     liquibaseRuntime 'info.picocli:picocli:4.6.1'
     liquibaseRuntime 'org.postgresql:postgresql:42.6.0'
     liquibaseRuntime 'ch.qos.logback:logback-classic:1.4.8'


### PR DESCRIPTION
Verily security has started using a different dependency analysis tool which flagged a handful of vulnerabilities. I'd like to update dependencies to fix issues raised by both Verily's tool and Sourceclear.

I verified the dependency versions are changed by generating lockfiles locally, though it looks like this service generally isn't using them anymore so I didn't include them in this PR.