### PR TITLE
[WOR-1411] Enable prometheus scrapable endpoints

### DIFF
--- a/service/src/main/resources/policy-application.yml
+++ b/service/src/main/resources/policy-application.yml
@@ -67,6 +67,12 @@ policy:
 management:
   server:
     port: 9098
+  endpoints:
+    prometheus:
+      enabled: true
+    web:
+      exposure:
+        include: "prometheus"
 
 otel:
   sdk:

--- a/service/src/main/resources/policy-application.yml
+++ b/service/src/main/resources/policy-application.yml
@@ -73,6 +73,14 @@ management:
     web:
       exposure:
         include: "prometheus"
+  metrics:
+    distribution:
+      # Used to publish a histogram suitable for computing aggregable (across dimensions) percentile
+      # latency approximations in Prometheus (by using histogram_quantile)
+      # For more information: https://micrometer.io/docs/concepts#_histograms_and_percentiles
+      minimum-expected-value[http.server.requests]: 10ms
+      maximum-expected-value[http.server.requests]: 10s
+      percentiles-histogram[http.server.requests]: true
 
 otel:
   sdk:


### PR DESCRIPTION
TPS is not exposing metrics in a way that is scrape-able by Prometheus for usage in Grafana. 

### This PR:
* Switches to a prometheus scrape-able format, with the metrics available at /actuator/prometheus
* Adds percentile histograms for request latencies. I've taken a stab at the bucket min/max of 10ms/10s. Given that TPS makes no calls to external services this seems like a reasonable place to start.  [See this reference PR](https://github.com/DataBiosphere/terra-drs-hub/pull/90)