### PR TITLE
ID-947 Upgrade logback to fix vulnerability.

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     liquibaseRuntime 'org.liquibase:liquibase-core:4.20.0'
     liquibaseRuntime 'info.picocli:picocli:4.6.1'
     liquibaseRuntime 'org.postgresql:postgresql:42.6.0'
-    liquibaseRuntime 'ch.qos.logback:logback-classic:1.4.8'
+    liquibaseRuntime 'ch.qos.logback:logback-classic:1.4.14'
 
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor:$springBootVersion"
 


### PR DESCRIPTION
```
The following version in use was found to contain a vulnerability: 1.4.11

Upgrading to a non-vulnerable version of this library will fix this finding. The fixed version of this library is: 1.4.12
```
The newest version is 1.4.14 so I upgraded to that. 