### PR TITLE
ID-947 Upgrade logback to fix vulnerability. Take 2.

### DIFF
--- a/buildSrc/src/main/groovy/bio.terra.policy.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.policy.java-common-conventions.gradle
@@ -44,7 +44,8 @@ dependencies {
     compileOnly "com.google.code.findbugs:annotations:3.0.1"
     implementation 'org.slf4j:slf4j-api:2.0.7'
 
-    testImplementation 'ch.qos.logback:logback-classic:1.4.8'
+    testImplementation 'ch.qos.logback:logback-classic:1.4.14'
+    testImplementation 'ch.qos.logback:logback-core:1.4.14'
     testImplementation 'org.hamcrest:hamcrest:2.2'
 
     implementation 'io.swagger.core.v3:swagger-annotations:2.2.0'

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
     implementation 'com.google.oauth-client:google-oauth-client:1.33.3'
     implementation 'org.scala-lang:scala-library:2.13.10' //required by the sam-client
-    implementation('bio.terra:terra-common-lib:0.1.5-SNAPSHOT') {
+    implementation('bio.terra:terra-common-lib:0.1.10-SNAPSHOT') {
         exclude group: 'org.springframework.boot'
         exclude group: 'org.yaml', module: 'snakeyaml'
     }
@@ -55,6 +55,8 @@ dependencies {
     implementation "org.springframework:spring-aop:6.0.11"
     implementation 'org.springframework:spring-aspects:6.0.11'
     implementation 'io.sentry:sentry-spring-boot-starter:6.18.1'
+    implementation 'ch.qos.logback:logback-classic:1.4.14'
+    implementation 'ch.qos.logback:logback-core:1.4.14'
 
     implementation 'org.apache.commons:commons-lang3:3.12.0'
 
@@ -62,6 +64,7 @@ dependencies {
     liquibaseRuntime 'info.picocli:picocli:4.6.1'
     liquibaseRuntime 'org.postgresql:postgresql:42.6.0'
     liquibaseRuntime 'ch.qos.logback:logback-classic:1.4.14'
+    liquibaseRuntime 'ch.qos.logback:logback-core:1.4.14'
 
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor:$springBootVersion"
 


### PR DESCRIPTION
I accidentally only upgraded it for the migration last time wooops. This time I double checked with a dependency scan.