### PR TITLE
[CORE-45] Upgrade Base Image to jre:17-12-distroless for Security Fix

### DIFF
--- a/service/publishing.gradle
+++ b/service/publishing.gradle
@@ -21,7 +21,7 @@ task extractProfilerAgent(dependsOn: downloadProfilerAgent, type: Copy) {
 jib {
     from {
         // see https://github.com/broadinstitute/dsp-appsec-blessed-images/tree/main/jre
-        image = "us.gcr.io/broad-dsp-gcr-public/base/jre:17-distroless"
+        image = "us.gcr.io/broad-dsp-gcr-public/base/jre:17-12-distroless"
     }
     extraDirectories {
         paths = [file(jibExtraDirectory)]


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-45

**Description:**

This PR upgrades the base image from jre:17-distroless to jre:17-12-distroless to fix a security vulnerability. Service compatibility has been checked, and tests have been run to ensure everything works as expected.

**Infosec Discussion:**

Reference: [Message from David Bernick in #dsp-engineering.](https://broadinstitute.slack.com/archives/C0DSD41QT/p1728328182615109)