### PR TITLE
[CORE-34] Add CSP Header to Swagger Page

### DIFF
--- a/service/src/main/resources/templates/swagger-ui.html
+++ b/service/src/main/resources/templates/swagger-ui.html
@@ -3,6 +3,7 @@
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
   <head>
     <meta charset="UTF-8">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self'; form-action 'none';">
     <title>Terra Policy Service Swagger UI</title>
     <link rel="stylesheet" type="text/css" href="/webjars/swagger-ui-dist/swagger-ui.css" >
     <link rel="icon" type="image/png" href="/webjars/swagger-ui-dist/favicon-32x32.png" sizes="32x32" />


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CORE-34

**Description:**

This PR adds a Content Security Policy (CSP) header to the Terra Policy Service (TPS) Swagger page to enhance security by reducing the risk of cross-site scripting (XSS) and data injection attacks.

**Testing:**

- Verified the Swagger page displays correctly with the CSP header.
- Checked for any security warnings or content issues.