### PR TITLE
CORE-246 Upgrading to cache v4

### DIFF
--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -108,7 +108,7 @@ jobs:
         java-version: 17
 
     - name: Cache Gradle packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.gradle/caches


### PR DESCRIPTION
Jira: [\<Link to Jira ticket\>](https://broadworkbench.atlassian.net/browse/CORE-246)

What:

Upgrades all actions/cache to v4

Why:

  The cache backend service has been rewritten from the ground up for improved performance and reliability. [actions/cache](https://github.com/actions/cache) now integrates with the new cache service (v2) APIs.

The new service will gradually roll out as of February 1st, 2025. The legacy service will also be sunset on the same date. Changes in these release are fully backward compatible.

More info here: https://github.com/marketplace/actions/cache

How:

This makes all our repos use the same version of actions/cache.
  
