### PR TITLE
[CORE-593] Don't set contents permissions

### DIFF
--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -62,7 +62,6 @@ jobs:
   tag-publish-docker-deploy:
     needs: [ bump-check ]
     permissions:
-      contents: 'read'
       id-token: 'write'
     runs-on: ubuntu-latest
     if: needs.bump-check.outputs.is-bump == 'no'


### PR DESCRIPTION
https://github.com/DataBiosphere/terra-policy-service/pull/110 added a `permissions` block to `tag-publish.yml`.  Usually, in order to publish to GAR, this `permissions` block consists of 
```
contents: 'read'
id-token: 'write'

```
However, the publishing job [failed](https://github.com/DataBiosphere/terra-policy-service/actions/runs/16272961038/job/45944996842).  In testing the PR, when this step failed, I thought it was because it was not a "real" publishing, which has been the case in other repos, but when it failed on merge I looked closer.  I *think* what is happening here is that the `contents` permission had previously been `write` and I've overwritten it; looking at the last [successful job](https://github.com/DataBiosphere/terra-policy-service/actions/runs/15418981735/job/43388697370#step:1:20) before this PR it looks like `contents` permissions had already been present with `write`; therefore I think I don't need to add `contents: read` in this case and have removed that line.
