### PR TITLE
[CORE-593] Fix GCR publishing

### DIFF
--- a/service/src/main/java/bio/terra/policy/service/pao/graph/model/AttributeEvaluator.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/graph/model/AttributeEvaluator.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
  * </ol>
  */
 public class AttributeEvaluator {
+  private static final Logger logger = LoggerFactory.getLogger(AttributeEvaluator.class);
   private final Map<String, List<GraphAttribute>> inputs;
   private final Pao containingPao; // The PAO we are evaluating
 

--- a/service/src/main/java/bio/terra/policy/service/pao/model/Pao.java
+++ b/service/src/main/java/bio/terra/policy/service/pao/model/Pao.java
@@ -16,7 +16,7 @@ public class Pao {
   private final PaoObjectType objectType;
   private PolicyInputs attributes;
   private PolicyInputs effectiveAttributes;
-  private Set<UUID> sourceObjectIds;
+  private final Set<UUID> sourceObjectIds;
   private boolean deleted;
   private Instant created;
   private Instant lastUpdated;


### PR DESCRIPTION
Previous runs failed to publish because they were still [authed](https://github.com/DataBiosphere/terra-policy-service/actions/runs/16277166796/job/45958748353#step:13:22) under the GAR SA.  Switching to the auth method used in other repos seems to have [fixed](https://github.com/DataBiosphere/terra-policy-service/actions/runs/16277364917/job/45959396618) it.