### PR TITLE
CORE-648: proper links in PaoDao javadoc

### DIFF
--- a/service/src/main/java/bio/terra/policy/db/PaoDao.java
+++ b/service/src/main/java/bio/terra/policy/db/PaoDao.java
@@ -179,11 +179,11 @@ public class PaoDao {
    * Given a source id, RECURSIVELY find all of the dependents and return their ids. Consult the
    * documentation on Postgres recursive queries in this document:
    *
-   * <p>https://www.postgresql.org/docs/current/queries-with.html
+   * <p><a href="https://www.postgresql.org/docs/current/queries-with.html">https://www.postgresql.org/docs/current/queries-with.html</a>
    *
    * <p>And in this tutorial:
    *
-   * <p>https://www.postgresqltutorial.com/postgresql-tutorial/postgresql-recursive-query/
+   * <p><a href="https://www.postgresqltutorial.com/postgresql-tutorial/postgresql-recursive-query/">https://www.postgresqltutorial.com/postgresql-tutorial/postgresql-recursive-query/</a>
    *
    * @param sourceId source to hunt for
    * @return Set of all dependent UUIDs

--- a/service/src/main/java/bio/terra/policy/db/PaoDao.java
+++ b/service/src/main/java/bio/terra/policy/db/PaoDao.java
@@ -179,11 +179,13 @@ public class PaoDao {
    * Given a source id, RECURSIVELY find all of the dependents and return their ids. Consult the
    * documentation on Postgres recursive queries in this document:
    *
-   * <p><a href="https://www.postgresql.org/docs/current/queries-with.html">https://www.postgresql.org/docs/current/queries-with.html</a>
+   * <p><a
+   * href="https://www.postgresql.org/docs/current/queries-with.html">https://www.postgresql.org/docs/current/queries-with.html</a>
    *
    * <p>And in this tutorial:
    *
-   * <p><a href="https://www.postgresqltutorial.com/postgresql-tutorial/postgresql-recursive-query/">https://www.postgresqltutorial.com/postgresql-tutorial/postgresql-recursive-query/</a>
+   * <p><a
+   * href="https://www.postgresqltutorial.com/postgresql-tutorial/postgresql-recursive-query/">https://www.postgresqltutorial.com/postgresql-tutorial/postgresql-recursive-query/</a>
    *
    * @param sourceId source to hunt for
    * @return Set of all dependent UUIDs


### PR DESCRIPTION
for troubleshooting CORE-648.

This PR tweaks the javadoc for `PaoDao`.

The PR's main purpose is to test client publishing after merge to see if we continue to run into the same errors we see in https://github.com/DataBiosphere/terra-policy-service/actions/runs/16761362156/job/47512890822.