### PR TITLE
CORE-648: update exporter-trace, which updates protobuf

### DIFF
--- a/buildSrc/src/main/groovy/bio.terra.policy.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.policy.java-common-conventions.gradle
@@ -61,7 +61,7 @@ dependencies {
     implementation "io.opentelemetry.instrumentation:opentelemetry-spring-webmvc-6.0:${openTelemetryVersion}-alpha"
     implementation "io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:${openTelemetryVersion}"
     implementation "io.opentelemetry.instrumentation:opentelemetry-spring-boot:${openTelemetryVersion}-alpha"
-    implementation "com.google.cloud.opentelemetry:exporter-trace:0.25.2"
+    implementation "com.google.cloud.opentelemetry:exporter-trace:0.36.0"
 }
 
 tasks.named('test') {
@@ -99,8 +99,6 @@ dependencies {
         // The latest version of spotbugs still pulls in a vulnerable dependency.
         // This can be removed when a new spotbugs version is available.
         spotbugs 'org.apache.bcel:bcel:6.6.1'
-        // CVE-2024-7254
-        implementation 'com.google.protobuf:protobuf-java:3.25.5'
     }
 }
 spotbugsMain {


### PR DESCRIPTION
CORE-648

Update the `com.google.cloud.opentelemetry:exporter-trace` direct dependency, which updates `protobuf` as a transitive dependency to address CVE-2024-7254. This also allows us to remove the `constraint` on `protobuf`, since constraints do not always translate properly into POM files which can cause errors in publishing jars.

Here's the output of `gw :service:dependencyInsight --dependency com.google.protobuf:protobuf-java --configuration runtimeClasspath` showing that protobuf is updated to 3.25.5:
<img width="1066" height="795" alt="Screenshot 2025-08-06 at 11 25 29 AM" src="https://github.com/user-attachments/assets/674d1f78-c57f-4882-9292-0ccd6da09e19" />
