### PR TITLE
CORE-657: add broad-artifactory registry for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ registries:
     url: https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-release-standard/
 updates:
   - package-ecosystem: "gradle"
+    registries:
+      - "broad-artifactory"
     directory: "/"
     open-pull-requests-limit: 10
     groups:


### PR DESCRIPTION
Follow-on to #123: actually use the `broad-artifactory` private registry in Dependabot updates.