### PR TITLE
CORE-657: remove broad-artifactory from Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,6 @@
 version: 2
-registries:
-  broad-artifactory:
-    type: maven-repository
-    url: https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-release-standard/
 updates:
   - package-ecosystem: "gradle"
-    registries:
-      - "broad-artifactory"
     directory: "/"
     open-pull-requests-limit: 10
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ registries:
     url: https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-release-standard/
 updates:
   - package-ecosystem: "gradle"
+    registries:
+      - "broad-artifactory"
     directory: "/"
     open-pull-requests-limit: 10
     groups:


### PR DESCRIPTION
CORE-657

followup to #123 and #124. Removes `broad-artifactory` from Dependabot config. This was working in another repo (WDS) but not working here. I'm not sure why; just removing it for now. The only dependency I can find in TPS from that repo is terra-common-lib.