### PR TITLE
CTM-426: Upgrade spring-boot-starter-actuator to 3.5.12

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -29,7 +29,7 @@ dependencyManagement {
     }
 }
 
-def springBootVersion = '3.5.7'
+def springBootVersion = '3.5.12'
 
 dependencies {
 


### PR DESCRIPTION
Ticket: [CTM-426](https://broadworkbench.atlassian.net/browse/CTM-426)

Upgrades spring-boot from 3.5.7 to 3.5.12 to address security vulnerabilities in spring-boot-starter-actuator.

[CTM-426]: https://broadworkbench.atlassian.net/browse/CTM-426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ