### PR TITLE
CTM-572: bump jackson, spring boot plugin, and bouncycastle

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     implementation 'io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.1.7'
     implementation 'org.hidetake.swagger.generator:org.hidetake.swagger.generator.gradle.plugin:2.19.1'
     implementation 'org.sonarqube:org.sonarqube.gradle.plugin:6.2.0.5505'
-    implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.5.7'
+    implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.5.12'
 
     // Commons lib required by jib
     implementation 'org.apache.commons:commons-lang3:3.20.0'

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -30,6 +30,24 @@ dependencyManagement {
     dependencies {
         dependency 'org.thymeleaf:thymeleaf:3.1.5.RELEASE'
         dependency 'org.thymeleaf:thymeleaf-spring6:3.1.5.RELEASE'
+        // Override the jackson versions pulled in by Spring Boot
+        dependency 'com.fasterxml.jackson.core:jackson-annotations:2.22'
+        dependencySet(group: 'com.fasterxml.jackson.core', version: '2.22.1') {
+            entry 'jackson-databind'
+            entry 'jackson-core'
+        }
+        dependencySet(group: 'com.fasterxml.jackson.datatype', version: '2.22.1') {
+            entry 'jackson-datatype-jdk8'
+            entry 'jackson-datatype-jsr310'
+            entry 'jackson-datatype-guava'
+        }
+        dependencySet(group: 'com.fasterxml.jackson.dataformat', version: '2.22.1') {
+            entry 'jackson-dataformat-yaml'
+            entry 'jackson-dataformat-cbor'
+        }
+        dependencySet(group: 'com.fasterxml.jackson.module', version: '2.22.1') {
+            entry 'jackson-module-parameter-names'
+        }
     }
 }
 
@@ -40,7 +58,6 @@ dependencies {
     implementation 'com.google.guava:guava:33.5.0-jre'
     implementation 'org.apache.taglibs:taglibs-standard-impl:1.2.5'
     implementation 'org.json:json:20251224'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.20.1'
     implementation 'com.google.oauth-client:google-oauth-client:1.39.0'
     implementation 'org.scala-lang:scala-library:2.13.18' //required by the sam-client
     // when updating terra-common-lib, also update the opentelemetry versions in Java common conventions

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -48,6 +48,11 @@ dependencyManagement {
         dependencySet(group: 'com.fasterxml.jackson.module', version: '2.22.1') {
             entry 'jackson-module-parameter-names'
         }
+        dependencySet(group: 'org.bouncycastle', version: '1.85') {
+            entry 'bcpkix-jdk18on'
+            entry 'bcutil-jdk18on'
+            entry 'bcprov-jdk18on'
+        }
     }
 }
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CTM-572

Bumps the Jackson suite of dependencies to 2.22.1. (CTM-572)

Bumps the `spring-boot-gradle-plugin` to 3.5.12 to match the version of Spring Boot libs elsewhere in dependencies.

Bumps the bouncycastle dependencies to 1.85. (CTM-598)