### PR TITLE
CTM-572: Bump Google auth action from v2 to v3 in tag-publish

### DIFF
--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -121,7 +121,7 @@ jobs:
       run: chmod +x gradlew
 
     - name: Authenticate to GCP
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@v3
       with:
         token_format: access_token
         workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'


### PR DESCRIPTION
## Summary
`client:publish` started failing with a 401 hitting Artifact Registry's Maven endpoint (run: https://github.com/DataBiosphere/terra-policy-service/actions/runs/30294012486/job/90084951736), blocking the CTM-572 release.

No changes to this workflow, `build.gradle`, or the pinned GAR Gradle plugin version since the last successful publish (May 2026), and the `@v2` tag itself hasn't moved either. The one consistent difference from repos that published successfully today with the same WIF setup (`jade-data-repo`, `teaspoons`) is that both use `google-github-actions/auth@v3`; this repo was still on `@v2`. Not confirmed as root cause, but it's the leading theory. Bumping to match.

## Test plan
- [ ] Confirm next tag-publish run succeeds