### PR TITLE
CTM-598: upgrade GAR plugin 2.1.5->2.23

### DIFF
--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -84,7 +84,7 @@ jobs:
         echo "checkout-branch=$CHECKOUT_BRANCH" >> $GITHUB_OUTPUT
 
     - name: Checkout current code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
       with:
         ref: ${{ steps.controls.outputs.checkout-branch }}
         token: ${{ secrets.BROADBOT_TOKEN }}
@@ -120,6 +120,9 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
 
+    - name: 'Set up Cloud SDK'
+      uses: 'google-github-actions/setup-gcloud@v3'
+
     - name: Authenticate to GCP
       uses: google-github-actions/auth@v3
       with:
@@ -141,7 +144,7 @@ jobs:
         tag: ${{ steps.tag.outputs.tag }}
 
     - name: Auth to GCR
-      uses: google-github-actions/auth@v1
+      uses: google-github-actions/auth@v3
       with:
         credentials_json: ${{ secrets.GCR_PUBLISH_KEY_B64 }}
 

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'maven-publish'
     id 'io.spring.dependency-management'
     id 'org.hidetake.swagger.generator'
-    id 'com.google.cloud.artifactregistry.gradle-plugin' version '2.1.5'
+    id 'com.google.cloud.artifactregistry.gradle-plugin' version '2.2.5'
 }
 
 dependencyManagement {

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -5,7 +5,9 @@ plugins {
     id 'maven-publish'
     id 'io.spring.dependency-management'
     id 'org.hidetake.swagger.generator'
-    id 'com.google.cloud.artifactregistry.gradle-plugin' version '2.2.5'
+    // See https://github.com/GoogleCloudPlatform/artifact-registry-maven-tools/issues/106
+    // for the artifactregistry version
+    id 'com.google.cloud.artifactregistry.gradle-plugin' version '2.2.3'
 }
 
 dependencyManagement {


### PR DESCRIPTION
CTM-598

TPS is failing to publish its client library to Google Artifact Registry (GAR). See:
* https://github.com/DataBiosphere/terra-policy-service/actions/runs/30365184403
* https://github.com/DataBiosphere/terra-policy-service/actions/runs/30294012486

This PR upgrades to the latest version of the GAR Gradle plugin, to see if that resolves the issue.